### PR TITLE
discoverSkills: follow symlinks in skills directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -220,10 +220,6 @@ func discoverSkills(dir string) []string {
 	var skills []string
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
 		skillPath := filepath.Join(dir, entry.Name())
 		skillFile := filepath.Join(skillPath, "SKILL.md")
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -178,6 +180,32 @@ func TestNostrConfig_DMRelays(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestDiscoverSkills_Symlinks(t *testing.T) {
+	t.Parallel()
+
+	// Create a target directory with SKILL.md
+	target := t.TempDir()
+	if err := os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a skills dir with a symlink to the target
+	skillsDir := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(skillsDir, "my-skill")); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := discoverSkills(skillsDir)
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1: %v", len(skills), skills)
+	}
+
+	want := filepath.Join(skillsDir, "my-skill")
+	if skills[0] != want {
+		t.Errorf("skill path = %q, want %q", skills[0], want)
+	}
 }
 
 func TestNostrConfig_MissingRelays(t *testing.T) {


### PR DESCRIPTION
ReadDir's IsDir() returns false for symlinks pointing to directories, which breaks skill discovery when OPENCROW_PI_SKILLS_DIR is a Nix linkFarm (all entries are symlinks). Since we already stat SKILL.md inside each entry, the IsDir() guard is redundant — remove it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced skill discovery to properly support symlinked skill definitions.

* **Tests**
  * Added test coverage for symlink resolution in skill discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->