### PR TITLE
nostr: publish NIP-01 kind 0 profile metadata on startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,6 +47,10 @@ type NostrConfig struct {
 	BlossomServers []string            // OPENCROW_NOSTR_BLOSSOM_SERVERS
 	AllowedUsers   map[string]struct{} // OPENCROW_NOSTR_ALLOWED_USERS (hex pubkeys)
 	SessionBaseDir string              // shared with PiConfig.SessionDir
+	Name           string              // OPENCROW_NOSTR_NAME (kind 0 "name")
+	DisplayName    string              // OPENCROW_NOSTR_DISPLAY_NAME (kind 0 "display_name")
+	About          string              // OPENCROW_NOSTR_ABOUT (kind 0 "about")
+	Picture        string              // OPENCROW_NOSTR_PICTURE (kind 0 "picture" URL)
 }
 
 type PiConfig struct {
@@ -323,6 +327,10 @@ func loadNostrConfig(getenv func(string) string, sessionBaseDir string) (NostrCo
 		BlossomServers: parseCommaSeparated(getenv("OPENCROW_NOSTR_BLOSSOM_SERVERS")),
 		AllowedUsers:   allowedUsers,
 		SessionBaseDir: sessionBaseDir,
+		Name:           getenv("OPENCROW_NOSTR_NAME"),
+		DisplayName:    getenv("OPENCROW_NOSTR_DISPLAY_NAME"),
+		About:          getenv("OPENCROW_NOSTR_ABOUT"),
+		Picture:        getenv("OPENCROW_NOSTR_PICTURE"),
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -172,6 +172,12 @@ func createNostrBackend(cfg *Config, handler backend.MessageHandler) (*nostrback
 		BlossomServers: cfg.Nostr.BlossomServers,
 		AllowedUsers:   cfg.Nostr.AllowedUsers,
 		SessionBaseDir: cfg.Pi.SessionDir,
+		Profile: nostrbackend.ProfileConfig{
+			Name:        cfg.Nostr.Name,
+			DisplayName: cfg.Nostr.DisplayName,
+			About:       cfg.Nostr.About,
+			Picture:     cfg.Nostr.Picture,
+		},
 	}
 
 	b, err := nostrbackend.NewBackend(nostrCfg, handler)

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -151,6 +151,30 @@ in
             description = "Comma-separated npubs or hex pubkeys allowed to interact with the bot. Empty allows all.";
           };
 
+          OPENCROW_NOSTR_NAME = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Bot profile name (NIP-01 kind 0 'name' field).";
+          };
+
+          OPENCROW_NOSTR_DISPLAY_NAME = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Bot profile display name (NIP-01 kind 0 'display_name' field).";
+          };
+
+          OPENCROW_NOSTR_ABOUT = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Bot profile about/bio (NIP-01 kind 0 'about' field).";
+          };
+
+          OPENCROW_NOSTR_PICTURE = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Bot profile picture URL (NIP-01 kind 0 'picture' field).";
+          };
+
           OPENCROW_PI_PROVIDER = lib.mkOption {
             type = lib.types.str;
             default = "anthropic";

--- a/nostr/backend.go
+++ b/nostr/backend.go
@@ -3,6 +3,7 @@ package nostr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -17,6 +18,14 @@ import (
 	"github.com/pinpox/opencrow/backend"
 )
 
+// ProfileConfig holds NIP-01 kind 0 metadata fields.
+type ProfileConfig struct {
+	Name        string // NIP-01 "name"
+	DisplayName string // NIP-01 "display_name"
+	About       string // NIP-01 "about"
+	Picture     string // NIP-01 "picture"
+}
+
 // Config holds Nostr-specific configuration.
 type Config struct {
 	PrivateKey     string
@@ -25,6 +34,7 @@ type Config struct {
 	BlossomServers []string
 	AllowedUsers   map[string]struct{}
 	SessionBaseDir string
+	Profile        ProfileConfig
 }
 
 // Backend implements backend.Backend for Nostr NIP-17 DMs.
@@ -87,6 +97,9 @@ func (b *Backend) Run(ctx context.Context) error {
 	// Create keyer for NIP-44 encrypt/decrypt
 	kr := keyer.NewPlainKeySigner(b.keys.SK)
 	b.kr = kr
+
+	// Publish NIP-01 profile metadata (kind 0) so the bot has a name/about.
+	b.publishProfile(ctx)
 
 	// Publish NIP-17 DM relay list (kind 10050) so clients know where to
 	// send gift wraps. Without this, apps like 0xchat cannot discover the
@@ -194,6 +207,59 @@ func (b *Backend) discoverSubscriptionRelays(ctx context.Context) []string {
 	}
 
 	return relays
+}
+
+// publishProfile publishes a NIP-01 kind 0 metadata event so the bot
+// has a visible name, about, and picture on Nostr clients.
+func (b *Backend) publishProfile(ctx context.Context) {
+	p := b.cfg.Profile
+	if p.Name == "" && p.DisplayName == "" && p.About == "" && p.Picture == "" {
+		return
+	}
+
+	meta := make(map[string]string)
+	if p.Name != "" {
+		meta["name"] = p.Name
+	}
+	if p.DisplayName != "" {
+		meta["display_name"] = p.DisplayName
+	}
+	if p.About != "" {
+		meta["about"] = p.About
+	}
+	if p.Picture != "" {
+		meta["picture"] = p.Picture
+	}
+
+	content, err := json.Marshal(meta)
+	if err != nil {
+		slog.Error("nostr: failed to marshal profile metadata", "error", err)
+		return
+	}
+
+	evt := gonostr.Event{
+		Kind:      0,
+		CreatedAt: gonostr.Now(),
+		Content:   string(content),
+		PubKey:    b.keys.PK,
+	}
+	if err := evt.Sign(b.keys.SK); err != nil {
+		slog.Error("nostr: failed to sign profile event", "error", err)
+		return
+	}
+
+	for _, relayURL := range b.cfg.Relays {
+		r, err := b.pool.EnsureRelay(relayURL)
+		if err != nil {
+			slog.Warn("nostr: failed to connect for profile", "relay", relayURL, "error", err)
+			continue
+		}
+		if err := r.Publish(ctx, evt); err != nil {
+			slog.Warn("nostr: failed to publish profile", "relay", relayURL, "error", err)
+		} else {
+			slog.Info("nostr: published profile", "relay", relayURL)
+		}
+	}
 }
 
 // publishDMRelayList publishes a NIP-17 DM relay list (kind 10050) so


### PR DESCRIPTION
Bots appear as anonymous pubkeys on Nostr clients without a kind 0 profile event. Add OPENCROW_NOSTR_NAME, OPENCROW_NOSTR_DISPLAY_NAME, OPENCROW_NOSTR_ABOUT, and OPENCROW_NOSTR_PICTURE env vars that get published as a kind 0 event on startup, matching the pattern used for kind 10050 DM relay list publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bot profile configuration: Customize your NOSTR bot's profile metadata including name, display name, about information, and profile picture URL through new settings.
  * Profile information is automatically published to all configured relays when your bot starts, enabling Nostr clients to display your bot's complete profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->