### PR TITLE
opencrow: allow group to write to fifo

### DIFF
--- a/trigger_pipe.go
+++ b/trigger_pipe.go
@@ -239,7 +239,7 @@ func ensureFIFO(path string) error {
 		return fmt.Errorf("checking FIFO at %s: %w", path, err)
 	}
 
-	if err := syscall.Mkfifo(path, 0o644); err != nil {
+	if err := syscall.Mkfifo(path, 0o664); err != nil {
 		return fmt.Errorf("creating FIFO at %s: %w", path, err)
 	}
 


### PR DESCRIPTION
this allows to have services running as a different user to be part of the opencrow group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted system permissions to enable proper group access to shared resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->