### PR TITLE
RFC: module: add declarative skills option as attrset

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,30 +165,50 @@ containing a `SKILL.md` file with a YAML frontmatter (`name`, `description`) and
 the skill's instructions.
 
 OpenCrow ships with a `web` skill (for browsing with curl/lynx) and passes it to
-pi by default. To configure which skills are loaded, set `OPENCROW_PI_SKILLS` to
-a comma-separated list of skill directory paths:
+pi by default.
+
+### NixOS module
+
+The NixOS module provides a declarative `skills` option — an attrset mapping
+skill names to directories:
+
+```nix
+services.opencrow.skills = {
+  web = "${pkgs.opencrow}/share/opencrow/skills/web";  # included by default
+  kagi-search = "${mics-skills}/skills/kagi-search";
+  my-custom-skill = ./skills/my-custom-skill;
+};
+```
+
+All entries are assembled into a single directory via `linkFarm` and passed to
+pi through `OPENCROW_PI_SKILLS_DIR`. The attrset is mergeable, so skills can be
+added from multiple NixOS module files.
+
+### Environment variables
+
+When not using the NixOS module, configure skills via environment variables:
 
 ```
-OPENCROW_PI_SKILLS=/var/lib/opencrow/skills/web,/path/to/custom-skill
+OPENCROW_PI_SKILLS=/path/to/skill1,/path/to/skill2
+OPENCROW_PI_SKILLS_DIR=/path/to/skills-directory
 ```
 
-Each path should point to a directory containing a `SKILL.md` file. These are
-passed to pi via `--skill` flags.
+`OPENCROW_PI_SKILLS` is a comma-separated list of individual skill directories.
+`OPENCROW_PI_SKILLS_DIR` points to a directory whose subdirectories are scanned
+for `SKILL.md` files. Both can be used together.
 
-To write your own skill, create a directory with a `SKILL.md`:
+### Writing a skill
+
+Create a directory with a `SKILL.md`:
 
 ```markdown
 ---
-name: My Skill
-description: What this skill does
+name: my-skill
+description: What this skill does and when to use it
 ---
 
 Instructions for the agent on how to use this skill...
 ```
-
-When using the NixOS module, the default skill path points to the packaged
-`web` skill at `${cfg.package}/share/opencrow/skills/web`. Set
-`OPENCROW_PI_SKILLS` in the `environment` option to override or add more.
 
 ## Heartbeat
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -9,6 +9,13 @@ let
   cfg = config.services.opencrow;
   opencrowPkg = cfg.package;
 
+  # Assemble all declared skills into a single directory.
+  # Each skill is symlinked by its name, producing a flat
+  # layout that OPENCROW_PI_SKILLS_DIR can scan.
+  skillsDir = pkgs.linkFarm "opencrow-skills" (
+    lib.mapAttrsToList (name: path: { inherit name path; }) cfg.skills
+  );
+
   # Host-side wrapper to run pi inside the container as the opencrow user,
   # e.g. `opencrow-pi auth login` to complete OAuth.
   opencrowPi = pkgs.writeShellScriptBin "opencrow-pi" ''
@@ -34,6 +41,27 @@ in
       type = lib.types.package;
       description = "The pi coding agent package. Required — typically from llm-agents.nix or similar.";
       example = lib.literalExpression "llm-agents.packages.\${system}.pi";
+    };
+
+    skills = lib.mkOption {
+      type = lib.types.attrsOf lib.types.path;
+      default = {
+        web = "${opencrowPkg}/share/opencrow/skills/web";
+      };
+      defaultText = lib.literalExpression ''{ web = "''${opencrowPkg}/share/opencrow/skills/web"; }'';
+      description = ''
+        Skill directories to make available to pi, keyed by name. Each
+        value must be a path to a directory containing a SKILL.md file.
+        All skills are assembled into a single directory and passed via
+        OPENCROW_PI_SKILLS_DIR.
+      '';
+      example = lib.literalExpression ''
+        {
+          web = "''${opencrowPkg}/share/opencrow/skills/web";
+          my-custom-skill = ./my-custom-skill;
+          kagi-search = "''${pkgs.fetchFromGitHub { owner = "someone"; repo = "pi-skills"; rev = "main"; hash = "..."; }}/kagi-search";
+        }
+      '';
     };
 
     environmentFiles = lib.mkOption {
@@ -213,14 +241,15 @@ in
 
           OPENCROW_PI_SKILLS = lib.mkOption {
             type = lib.types.str;
-            default = "${opencrowPkg}/share/opencrow/skills/web";
-            description = "Comma-separated list of skill paths to pass to pi via --skill.";
+            default = "";
+            description = "Comma-separated list of additional skill paths to pass to pi via --skill. Prefer using the top-level `skills` option instead.";
           };
 
           OPENCROW_PI_SKILLS_DIR = lib.mkOption {
             type = lib.types.str;
-            default = "";
-            description = "Directory to scan for skill subdirectories (each must contain SKILL.md). Discovered skills are merged with OPENCROW_PI_SKILLS.";
+            default = toString skillsDir;
+            defaultText = lib.literalExpression ''"''${skillsDir}"'';
+            description = "Directory to scan for skill subdirectories (each must contain SKILL.md). Automatically populated from the `skills` option.";
           };
 
           OPENCROW_SOUL_FILE = lib.mkOption {


### PR DESCRIPTION
Replace the flat OPENCROW_PI_SKILLS string default with a structured `services.opencrow.skills` attrset (name → path). All entries are assembled into a linkFarm and passed via OPENCROW_PI_SKILLS_DIR.

The attrset approach is mergeable across multiple NixOS module files, so individual skill modules can simply set:

  services.opencrow.skills.kagi-search = "${mics-skills}/skills/kagi-search";

The bundled web skill is included by default. OPENCROW_PI_SKILLS remains available for additional comma-separated paths but defaults to empty now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added declarative skills configuration via NixOS module with named skill directories.
  * Skills are now automatically assembled into a single directory for scanning.

* **Documentation**
  * Updated Skills configuration guide with module-based setup instructions.
  * Added environment variable reference for OPENCROW_PI_SKILLS and OPENCROW_PI_SKILLS_DIR.
  * Added Writing a skill section with frontmatter examples and directory structure guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->