### PR TITLE
Drop room= from log lines

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -134,11 +134,11 @@ func (h *HeartbeatScheduler) tick(ctx context.Context, roomID string) bool {
 		return false
 	}
 
-	slog.Info("heartbeat firing", "room", roomID)
+	slog.Info("heartbeat firing")
 
 	pi, err := h.pool.Get(ctx, roomID)
 	if err != nil {
-		slog.Error("heartbeat: failed to get pi process", "room", roomID, "error", err)
+		slog.Error("heartbeat: failed to get pi process", "error", err)
 
 		return false
 	}
@@ -154,7 +154,7 @@ func (h *HeartbeatScheduler) readHeartbeatContent(roomID string) string {
 
 	heartbeatContent, err := os.ReadFile(heartbeatPath)
 	if err != nil && !os.IsNotExist(err) {
-		slog.Warn("failed to read HEARTBEAT.md", "room", roomID, "path", heartbeatPath, "error", err)
+		slog.Warn("failed to read HEARTBEAT.md", "path", heartbeatPath, "error", err)
 	}
 
 	return strings.TrimSpace(string(heartbeatContent))
@@ -165,7 +165,7 @@ func (h *HeartbeatScheduler) readHeartbeatContent(roomID string) string {
 func (h *HeartbeatScheduler) executeHeartbeatPrompt(ctx context.Context, pi *PiProcess, roomID, prompt string) bool {
 	reply, err := pi.PromptNoTouch(ctx, prompt, nil)
 	if errors.Is(err, ErrBusy) {
-		slog.Info("heartbeat: skipped, pi process busy with user prompt", "room", roomID)
+		slog.Info("heartbeat: skipped, pi process busy with user prompt")
 
 		return true
 	}
@@ -175,13 +175,13 @@ func (h *HeartbeatScheduler) executeHeartbeatPrompt(ctx context.Context, pi *PiP
 	}
 
 	if containsHeartbeatOK(reply) {
-		slog.Info("heartbeat: HEARTBEAT_OK, suppressing", "room", roomID)
+		slog.Info("heartbeat: HEARTBEAT_OK, suppressing")
 
 		return false
 	}
 
 	if reply == "" {
-		slog.Info("heartbeat: empty response, suppressing", "room", roomID)
+		slog.Info("heartbeat: empty response, suppressing")
 
 		return false
 	}
@@ -195,12 +195,12 @@ func (h *HeartbeatScheduler) executeHeartbeatPrompt(ctx context.Context, pi *PiP
 // Returns true when the heartbeat should be retried later.
 func (h *HeartbeatScheduler) handleHeartbeatError(ctx context.Context, roomID string, err error) bool {
 	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		slog.Info("heartbeat: aborted by user prompt", "room", roomID)
+		slog.Info("heartbeat: aborted by user prompt")
 
 		return true // skip, don't update lastBeat so we retry
 	}
 
-	slog.Error("heartbeat: pi prompt failed", "room", roomID, "error", err)
+	slog.Error("heartbeat: pi prompt failed", "error", err)
 	h.pool.Remove(roomID)
 
 	return false

--- a/pi.go
+++ b/pi.go
@@ -35,7 +35,6 @@ type PiProcess struct {
 	done       chan struct{}
 	mu         sync.Mutex
 	lastUse    time.Time
-	roomID     string
 	onToolCall func(ToolCallEvent) // optional callback for tool_execution_start events
 
 	// cancelMu protects cancelFunc for concurrent access from Abort().
@@ -66,10 +65,10 @@ func StartPi(ctx context.Context, cfg PiConfig, roomID string) (*PiProcess, erro
 	cmd.Dir = cfg.WorkingDir
 	cmd.Env = os.Environ()
 
-	return startPiProcess(cmd, roomID, cfg.SessionDir)
+	return startPiProcess(cmd, cfg.SessionDir)
 }
 
-func startPiProcess(cmd *exec.Cmd, roomID, sessionDir string) (*PiProcess, error) {
+func startPiProcess(cmd *exec.Cmd, sessionDir string) (*PiProcess, error) {
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe: %w", err)
@@ -94,13 +93,13 @@ func startPiProcess(cmd *exec.Cmd, roomID, sessionDir string) (*PiProcess, error
 		return nil, fmt.Errorf("starting pi: %w", err)
 	}
 
-	slog.Info("pi process started", "room", roomID, "pid", cmd.Process.Pid, "session_dir", sessionDir)
+	slog.Info("pi process started", "pid", cmd.Process.Pid, "session_dir", sessionDir)
 
 	// Log stderr in background
 	go func() {
 		scanner := bufio.NewScanner(stderrPipe)
 		for scanner.Scan() {
-			slog.Debug("pi stderr", "room", roomID, "line", scanner.Text())
+			slog.Debug("pi stderr", "line", scanner.Text())
 		}
 	}()
 
@@ -114,7 +113,7 @@ func startPiProcess(cmd *exec.Cmd, roomID, sessionDir string) (*PiProcess, error
 
 		close(done)
 
-		slog.Info("pi process exited", "room", roomID)
+		slog.Info("pi process exited")
 	}()
 
 	return &PiProcess{
@@ -123,7 +122,6 @@ func startPiProcess(cmd *exec.Cmd, roomID, sessionDir string) (*PiProcess, error
 		stdout:  scanner,
 		done:    done,
 		lastUse: time.Now(),
-		roomID:  roomID,
 	}, nil
 }
 
@@ -186,7 +184,7 @@ func (p *PiProcess) Prompt(ctx context.Context, message string, onToolCall ...fu
 	// If lock is held (likely by a heartbeat), abort it so user messages
 	// always take priority. The heartbeat will retry on the next tick.
 	if !p.mu.TryLock() {
-		slog.Info("prompt: lock contended, aborting running operation", "room", p.roomID)
+		slog.Info("prompt: lock contended, aborting running operation")
 		p.Abort()
 		p.mu.Lock()
 	}
@@ -255,7 +253,7 @@ func (p *PiProcess) Kill() {
 	case <-p.done:
 		return
 	case <-time.After(5 * time.Second):
-		slog.Warn("pi process did not exit after SIGINT, sending SIGKILL", "room", p.roomID)
+		slog.Warn("pi process did not exit after SIGINT, sending SIGKILL")
 		_ = p.cmd.Process.Kill()
 		<-p.done
 	}
@@ -355,7 +353,7 @@ func (p *PiProcess) sendAbort() {
 
 	abortData, err := json.Marshal(abort)
 	if err != nil {
-		slog.Warn("failed to marshal abort command", "room", p.roomID, "error", err)
+		slog.Warn("failed to marshal abort command", "error", err)
 
 		return
 	}
@@ -396,18 +394,18 @@ func (p *PiProcess) readUntilAgentEnd() (string, error) {
 func (p *PiProcess) handleRPCLine(line string) (string, bool, error) {
 	var evt rpcEvent
 	if err := json.Unmarshal([]byte(line), &evt); err != nil {
-		slog.Warn("malformed JSON from pi", "room", p.roomID, "error", err, "line", line)
+		slog.Warn("malformed JSON from pi", "error", err, "line", line)
 
 		return "", false, nil
 	}
 
-	slog.Debug("pi rpc event", "room", p.roomID, "type", evt.Type)
+	slog.Debug("pi rpc event", "type", evt.Type)
 
 	switch evt.Type {
 	case "agent_end":
 		text := extractLastAssistantText(evt.Messages)
 		if text == "" {
-			slog.Warn("agent_end contained no assistant text", "room", p.roomID, "messages_len", len(evt.Messages))
+			slog.Warn("agent_end contained no assistant text", "messages_len", len(evt.Messages))
 		}
 
 		return text, true, nil
@@ -444,7 +442,7 @@ func (p *PiProcess) autoRespondExtensionUI(evt rpcEvent) {
 
 		data, err := json.Marshal(resp)
 		if err != nil {
-			slog.Warn("failed to marshal extension_ui_response", "room", p.roomID, "error", err)
+			slog.Warn("failed to marshal extension_ui_response", "error", err)
 
 			return
 		}
@@ -452,7 +450,7 @@ func (p *PiProcess) autoRespondExtensionUI(evt rpcEvent) {
 		data = append(data, '\n')
 
 		if _, err := p.stdin.Write(data); err != nil {
-			slog.Warn("failed to send extension_ui_response", "room", p.roomID, "error", err)
+			slog.Warn("failed to send extension_ui_response", "error", err)
 		}
 	}
 	// Fire-and-forget methods (notify, setStatus, setWidget, setTitle, set_editor_text) are ignored.

--- a/pi_pool.go
+++ b/pi_pool.go
@@ -62,7 +62,7 @@ func (pool *PiPool) Remove(roomID string) {
 	pool.mu.Unlock()
 
 	if ok {
-		slog.Info("removing pi process", "room", roomID)
+		slog.Info("removing pi process")
 		p.Kill()
 	}
 }
@@ -93,8 +93,8 @@ func (pool *PiPool) StopAll() {
 	pool.processes = make(map[string]*PiProcess)
 	pool.mu.Unlock()
 
-	for roomID, p := range procs {
-		slog.Info("stopping pi process", "room", roomID)
+	for _, p := range procs {
+		slog.Info("stopping pi process")
 		p.Kill()
 	}
 }
@@ -148,7 +148,7 @@ func (pool *PiPool) reapIdle() {
 	pool.mu.Unlock()
 
 	for _, roomID := range toReap {
-		slog.Info("reaping idle pi process", "room", roomID)
+		slog.Info("reaping idle pi process")
 		pool.Remove(roomID)
 	}
 }

--- a/trigger_pipe.go
+++ b/trigger_pipe.go
@@ -80,7 +80,7 @@ func (t *TriggerPipeManager) StartRoom(ctx context.Context, roomID string) {
 	pipePath := TriggerPipePath(t.piCfg.SessionDir)
 
 	if err := ensureFIFO(pipePath); err != nil {
-		slog.Warn("trigger: failed to ensure FIFO", "room", roomID, "path", pipePath, "error", err)
+		slog.Warn("trigger: failed to ensure FIFO", "path", pipePath, "error", err)
 
 		return
 	}
@@ -132,7 +132,7 @@ func (t *TriggerPipeManager) readLoop(ctx context.Context, roomID, pipePath stri
 	// Open with O_RDWR so the fd stays open even when writers close their end.
 	f, err := os.OpenFile(pipePath, os.O_RDWR, 0)
 	if err != nil {
-		slog.Error("trigger: failed to open FIFO", "room", roomID, "path", pipePath, "error", err)
+		slog.Error("trigger: failed to open FIFO", "path", pipePath, "error", err)
 
 		return
 	}
@@ -156,12 +156,12 @@ func (t *TriggerPipeManager) readLoop(ctx context.Context, roomID, pipePath stri
 			return
 		}
 
-		slog.Info("trigger: received", "room", roomID, "content", line)
+		slog.Info("trigger: received", "content", line)
 		t.processTrigger(ctx, roomID, line)
 	}
 
 	if err := scanner.Err(); err != nil && ctx.Err() == nil {
-		slog.Warn("trigger: scanner error", "room", roomID, "error", err)
+		slog.Warn("trigger: scanner error", "error", err)
 	}
 }
 
@@ -172,7 +172,7 @@ func (t *TriggerPipeManager) processTrigger(ctx context.Context, roomID, content
 
 	pi, err := t.pool.Get(ctx, roomID)
 	if err != nil {
-		slog.Error("trigger: failed to get pi process", "room", roomID, "error", err)
+		slog.Error("trigger: failed to get pi process", "error", err)
 
 		return
 	}
@@ -181,20 +181,20 @@ func (t *TriggerPipeManager) processTrigger(ctx context.Context, roomID, content
 
 	reply, err := pi.PromptNoTouch(ctx, prompt)
 	if err != nil {
-		slog.Error("trigger: pi prompt failed", "room", roomID, "error", err)
+		slog.Error("trigger: pi prompt failed", "error", err)
 		t.pool.Remove(roomID)
 
 		return
 	}
 
 	if containsHeartbeatOK(reply) {
-		slog.Info("trigger: HEARTBEAT_OK, suppressing", "room", roomID)
+		slog.Info("trigger: HEARTBEAT_OK, suppressing")
 
 		return
 	}
 
 	if reply == "" {
-		slog.Info("trigger: empty response, suppressing", "room", roomID)
+		slog.Info("trigger: empty response, suppressing")
 
 		return
 	}


### PR DESCRIPTION
There is only a single room, so the long hash adds noise without information. The room ID still flows through function parameters and the pool map as a conversation key — only the log output is cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logging context by removing unnecessary identifiers from log entries across multiple system components. All functional behavior and control flow remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->