### PR TITLE
module: work around pam_lastlog2.so crash in systemd 259

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -401,6 +401,11 @@ in
         {
           system.stateVersion = "25.05";
 
+          # Work around broken pam_lastlog2.so missing libpam linkage in systemd 259
+          # https://github.com/NixOS/nixpkgs/issues/493934
+          # TODO: remove once https://github.com/NixOS/nixpkgs/pull/495347 lands in nixos-unstable
+          security.pam.services.login.updateWtmp = lib.mkForce false;
+
           users.users.opencrow = {
             isSystemUser = true;
             group = "opencrow";


### PR DESCRIPTION

The pam_lastlog2.so PAM module shipped with systemd 259 in nixpkgs is
missing libpam linkage, causing login sessions (and thus container
startup) to fail with 'Connection to the local host terminated.'

Disable updateWtmp for the login PAM service inside the container until
the upstream fix (NixOS/nixpkgs#495347) lands in nixos-unstable.

Link: https://github.com/NixOS/nixpkgs/issues/493934


