### PR TITLE
pi: decouple process lifetime from per-prompt context

### DIFF
--- a/app.go
+++ b/app.go
@@ -63,7 +63,7 @@ func (a *App) HandleMessage(ctx context.Context, msg backend.Message) {
 	// Record the incoming message so future reply-to references can quote it.
 	a.outbox.Put(ctx, msg.ConversationID, msg.MessageID, msg.Text)
 
-	switch msg.Text {
+	switch strings.TrimSpace(msg.Text) {
 	case "!help":
 		a.handleHelp(ctx, msg)
 	case "!restart":

--- a/app_test.go
+++ b/app_test.go
@@ -129,6 +129,8 @@ func TestApp_Commands(t *testing.T) {
 	}{
 		{"stop no session", "!stop", []string{"No active session"}, false},
 		{"compact no session", "!compact", []string{"No active session"}, false},
+		{"compact trailing whitespace", "!compact ", []string{"No active session"}, false},
+		{"help trailing newline", "!help\n", []string{"!help", "!restart"}, false},
 		{"help", "!help", []string{"!help", "!restart", "!stop", "!compact", "!skills"}, false},
 		{"restart", "!restart", []string{"Session restarted"}, true},
 		{"skills", "!skills", []string{"No skills loaded"}, false},

--- a/config.go
+++ b/config.go
@@ -64,6 +64,10 @@ type NostrConfig struct {
 
 type PiConfig struct {
 	BinaryPath string
+	// BinaryArgs are inserted before pi's own flags. Unused in production;
+	// tests use it to run the fake-pi stub via `bash <script>` so the
+	// testdata file needs no exec bit and no shebang lookup.
+	BinaryArgs []string
 	// SessionDir holds opencrow's internal state: pi session jsonl, opencrow.db,
 	// .room_id, trigger.pipe, downloaded attachments. Not the agent's cwd.
 	SessionDir string

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,6 +14,7 @@ buildGoModule (finalAttrs: {
       (lib.fileset.fileFilter (file: file.hasExt "go") ./..)
       (lib.fileset.fileFilter (file: file.hasExt "sql") ./..)
       ./../.golangci.yml
+      ./../testdata
       ./../skills
       ./../SOUL.md
     ];

--- a/pi.go
+++ b/pi.go
@@ -43,7 +43,13 @@ type PiProcess struct {
 // StartPi spawns a pi --mode rpc subprocess for the given room.
 // fresh=true omits --continue so pi creates a new session file
 // instead of resuming the most recent one from SessionDir.
-func StartPi(ctx context.Context, cfg PiConfig, roomID string, fresh bool) (*PiProcess, error) {
+//
+// The process is intentionally NOT bound to any caller context:
+// its lifetime is owned by Worker (idle reaper, Restart, Run shutdown
+// via stopPi). Binding it to the per-item ctx via exec.CommandContext
+// SIGKILLs pi the moment processItem returns, which is the bug behind
+// "No active session to compact".
+func StartPi(cfg PiConfig, roomID string, fresh bool) (*PiProcess, error) {
 	if err := os.MkdirAll(cfg.SessionDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating session dir: %w", err)
 	}
@@ -61,7 +67,8 @@ func StartPi(ctx context.Context, cfg PiConfig, roomID string, fresh bool) (*PiP
 
 	args := buildPiArgs(cfg, fresh)
 
-	cmd := exec.CommandContext(ctx, cfg.BinaryPath, args...) //nolint:gosec // binary path is from trusted config
+	// context.Background: see the doc comment on StartPi.
+	cmd := exec.CommandContext(context.Background(), cfg.BinaryPath, args...) //nolint:gosec // binary path is from trusted config
 	cmd.Dir = cfg.WorkingDir
 	cmd.Env = append(os.Environ(), "OPENCROW_SESSION_DIR="+cfg.SessionDir)
 
@@ -162,7 +169,9 @@ func startPiProcess(cmd *exec.Cmd, sessionDir string) (*PiProcess, error) {
 }
 
 func buildPiArgs(cfg PiConfig, fresh bool) []string {
-	args := []string{"--mode", "rpc", "--session-dir", cfg.SessionDir}
+	args := append([]string(nil), cfg.BinaryArgs...)
+
+	args = append(args, "--mode", "rpc", "--session-dir", cfg.SessionDir)
 	if !fresh {
 		args = append(args, "--continue")
 	}

--- a/testdata/fake-pi
+++ b/testdata/fake-pi
@@ -1,0 +1,16 @@
+# Minimal pi --mode rpc stub for tests: ack each prompt then idle.
+# Invoked as `bash testdata/fake-pi` (see PiConfig.BinaryArgs); no exec bit needed.
+# shellcheck shell=bash
+set -eu
+while IFS= read -r line; do
+  case "$line" in
+    *'"type":"prompt"'*|*'"type": "prompt"'*)
+      printf '%s\n' '{"type":"response","command":"prompt","success":true}'
+      printf '%s\n' '{"type":"agent_start"}'
+      printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"ok"}],"stopReason":"end_turn"}]}'
+      ;;
+    *'"type":"compact"'*|*'"type": "compact"'*)
+      printf '%s\n' '{"type":"response","command":"compact","success":true,"data":{"tokensBefore":1,"summary":"s"}}'
+      ;;
+  esac
+done

--- a/worker.go
+++ b/worker.go
@@ -532,7 +532,11 @@ func (w *Worker) ensurePi(ctx context.Context) (*PiProcess, error) {
 
 	roomID := w.resolveRoomID()
 
-	pi, err := StartPi(ctx, w.piCfg, roomID, fresh)
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("ensurePi cancelled: %w", ctx.Err())
+	}
+
+	pi, err := StartPi(w.piCfg, roomID, fresh) //nolint:contextcheck // see StartPi: process lifetime is worker-owned, not item-scoped
 	if err != nil {
 		return nil, err
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pinpox/opencrow/backend"
+)
+
+type stubBackend struct{}
+
+func (stubBackend) SetTyping(context.Context, string, bool)                    {}
+func (stubBackend) SendMessage(context.Context, string, string, string) string { return "" }
+func (stubBackend) MarkdownFlavor() backend.MarkdownFlavor                     { return backend.MarkdownNone }
+
+// newFakePiWorker builds a Worker wired to the bash fake-pi stub.
+// Cleanup stops the spawned process.
+func newFakePiWorker(t *testing.T) *Worker {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	script, err := filepath.Abs("testdata/fake-pi")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWorker(newTestInbox(t.Context(), t), PiConfig{
+		BinaryPath: "bash",
+		BinaryArgs: []string{script},
+		SessionDir: dir,
+		WorkingDir: dir,
+	}, "", "")
+	w.SetBackend(stubBackend{})
+	w.SetRoomID("room")
+
+	t.Cleanup(w.stopPi)
+
+	return w
+}
+
+// Regression for the "No active session to compact" bug seen on eve:
+// pi was spawned with exec.CommandContext bound to the per-item ctx,
+// which is cancelled the moment processItem returns. Go's CommandContext
+// then SIGKILLs pi, so by the time the next message (or !compact)
+// arrives the worker reports IsActive() == false. Journald showed
+// "pi: process exited" immediately after every "agent finished".
+//
+// The pi process lifetime is owned by the worker (idle reaper / Restart
+// / Run shutdown via stopPi), not by an individual prompt's context.
+func TestWorker_PiSurvivesItemContext(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	// Mirror processItem: a per-item ctx that is cancelled as soon as
+	// the prompt completes.
+	itemCtx, cancel := context.WithCancel(context.Background())
+
+	pi, reply, err := w.sendWithRetry(itemCtx, "hello")
+	if err != nil || reply != "ok" {
+		t.Fatalf("sendWithRetry = (%q, %v), want (ok, nil)", reply, err)
+	}
+
+	cancel() // processItem's defer cancel()
+
+	// CommandContext kills via a watcher goroutine after <-ctx.Done(),
+	// and IsAlive() reads p.done which a second goroutine closes after
+	// cmd.Wait(). Neither has run immediately after cancel() returns,
+	// so wait briefly for the bug to manifest if it's going to.
+	select {
+	case <-pi.done:
+		t.Fatal("pi process died after item ctx cancel; it must outlive individual prompts")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// A follow-up prompt must reuse the existing process, not respawn.
+	// On eve the dead process triggered sendWithRetry's "pi exited,
+	// starting fresh process" path on every message.
+	pi2, _, err := w.sendWithRetry(t.Context(), "again")
+	if err != nil {
+		t.Fatalf("second sendWithRetry: %v", err)
+	}
+
+	if pi2 != pi {
+		t.Fatal("second prompt spawned a new pi process; expected reuse")
+	}
+
+	// And the user-facing symptom: !compact must find a live session.
+	cr, err := pi2.Compact(t.Context())
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+
+	if cr.Summary != "s" || cr.TokensBefore != 1 {
+		t.Fatalf("compact result = %+v", cr)
+	}
+}


### PR DESCRIPTION
`!compact` always replied "No active session to compact" because the pi subprocess was being SIGKILLed immediately after every reply: `ensurePi` passed the per-item context (defer-cancelled in `processItem`) into `exec.CommandContext`, so Go's watcher goroutine tore the process down the moment a prompt finished. Journald on eve showed `pi: process exited` right after every `agent finished`, while running `pi --mode rpc` by hand stayed alive past `agent_end`. This regressed in 17088a8 when `ensurePi` started receiving the item-scoped ctx instead of the worker-lifetime one. The pi process is owned by the Worker (idle reaper / `Restart` / `Run` shutdown via `stopPi`), so spawn it with a background context and keep only a pre-spawn `ctx.Err()` check so preemption still short-circuits the start. A new regression test drives the worker against a bash `fake-pi` stub (invoked via `PiConfig.BinaryArgs` so testdata needs no exec bit) and asserts the process survives the item-ctx cancel, gets reused for the next prompt, and answers a `Compact()` round-trip; verified to fail on the old code and pass with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config now accepts custom binary arguments for the Pi process.
  * Pi process lifetime is decoupled from per-item operations and persists across item cancellations.

* **Bug Fixes**
  * Worker avoids starting Pi when the request context is already cancelled.

* **Tests**
  * Added regression tests verifying process persistence and compact behavior after per-item cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->