### PR TITLE
trigger: stop suppressing replies via HEARTBEAT_OK sentinel

### DIFF
--- a/config.go
+++ b/config.go
@@ -341,9 +341,7 @@ remind_at tool instead.`
 const defaultHeartbeatPrompt = `Run through the standing checks below.
 If nothing needs attention, reply with exactly: HEARTBEAT_OK`
 
-const defaultTriggerPrompt = `An external process sent a trigger message. Read the content below and act on it.
-You MUST fully process the trigger before deciding on a response. Only reply with
-exactly HEARTBEAT_OK if your processing rules explicitly tell you to ignore it.`
+const defaultTriggerPrompt = `External trigger received. Always respond with a brief human-readable summary for the user — never a status code or sentinel. If duplicate or no-op, say so.`
 
 func loadNostrConfig(env envReader) (NostrConfig, error) {
 	privateKey, err := loadNostrPrivateKey(env)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -155,16 +155,18 @@ func buildHeartbeatPrompt(basePrompt string, items []string) string {
 }
 
 // shouldSuppressReply returns true if the reply should not be forwarded
-// to the user — either because it contains HEARTBEAT_OK or is empty.
-func shouldSuppressReply(reply, label string) bool {
-	if strings.Contains(reply, "HEARTBEAT_OK") {
-		slog.Info(label + ": HEARTBEAT_OK, suppressing")
+// to the user. The HEARTBEAT_OK sentinel is honoured only for heartbeat
+// items — triggers are explicit external events and must always surface,
+// otherwise the model can silently swallow them by emitting the sentinel.
+func shouldSuppressReply(reply, source string) bool {
+	if source == sourceHeartbeat && strings.Contains(reply, "HEARTBEAT_OK") {
+		slog.Info(source + ": HEARTBEAT_OK, suppressing")
 
 		return true
 	}
 
 	if reply == "" {
-		slog.Info(label + ": empty response, suppressing")
+		slog.Info(source + ": empty response, suppressing")
 
 		return true
 	}


### PR DESCRIPTION
The default trigger prompt told the model it could reply HEARTBEAT_OK to ignore a trigger, and shouldSuppressReply() honoured that sentinel for all sources. In practice the model (observed with Qwen3.5-35B) would read a starred-email trigger, decide it had "already seen it" or that it was non-actionable, emit HEARTBEAT_OK, and the whole reply was silently dropped. The trigger content stayed in the pi conversation history, so the user only learned about it after sending the next message.

Triggers are explicit external events written to the FIFO; they must always surface. Restrict HEARTBEAT_OK suppression to heartbeat items and reword the trigger prompt to require a user-visible summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger response handling to generate human-readable summaries instead of status codes, delivering clearer and more meaningful feedback.
  * Enhanced detection and explicit reporting of duplicate or no-operation triggers to better inform users when triggers are redundant or ineffective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->