### PR TITLE
pi: reap full process tree on shutdown and join worker before exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,23 +92,30 @@ func run() int {
 
 	setupShutdown(b, cancel)
 
-	go worker.Run(ctx)
+	workerDone := spawnWorker(ctx, worker)
 
 	slog.Info("opencrow starting")
+
+	exitCode := 0
 
 	if err := b.Run(ctx); err != nil {
 		if ctx.Err() == nil {
 			slog.Error("backend exited with error", "error", err)
 
-			return 1
+			exitCode = 1
+		} else {
+			slog.Info("shutdown complete")
 		}
-
-		slog.Info("shutdown complete")
 	}
+
+	// Backend may have returned without a signal (error path); ensure
+	// the worker sees ctx.Done so the join below cannot hang.
+	cancel()
+	<-workerDone
 
 	_ = b.Close()
 
-	return 0
+	return exitCode
 }
 
 // sqliteDSNParams are the connection parameters for modernc.org/sqlite.
@@ -224,6 +231,23 @@ func createBackend(ctx context.Context, cfg *Config, handler backend.MessageHand
 	default:
 		return nil, fmt.Errorf("unsupported backend type: %q", cfg.BackendType)
 	}
+}
+
+// spawnWorker runs the worker loop in a goroutine and returns a channel
+// that closes when it exits. main must join on this before returning:
+// Worker.Run is the only path that calls stopPi on shutdown, and
+// os.Exit otherwise races it, leaving pi (plus tool subprocesses)
+// running. Pdeathsig in StartPi is the backstop, but graceful SIGTERM
+// via stopPi is the intended path.
+func spawnWorker(ctx context.Context, w *Worker) <-chan struct{} {
+	done := make(chan struct{})
+
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	return done
 }
 
 func setupShutdown(b backend.Backend, cancel context.CancelFunc) {

--- a/pi.go
+++ b/pi.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -71,28 +72,46 @@ func StartPi(cfg PiConfig, roomID string, fresh bool) (*PiProcess, error) {
 	cmd := exec.CommandContext(context.Background(), cfg.BinaryPath, args...) //nolint:gosec // binary path is from trusted config
 	cmd.Dir = cfg.WorkingDir
 	cmd.Env = append(os.Environ(), "OPENCROW_SESSION_DIR="+cfg.SessionDir)
+	// Own process group + Pdeathsig: Kill must take down tool
+	// subprocesses too, and pi must not outlive opencrow even if Kill
+	// never runs. See configurePiSysProcAttr.
+	configurePiSysProcAttr(cmd)
 
 	return startPiProcess(cmd, cfg.SessionDir)
 }
 
-// Kill terminates the pi process.
+// Kill terminates the pi process and every descendant it spawned.
+// Signalling only the leader is not enough: pi forks bash/curl/nix for
+// tool calls, and those get reparented to init when pi exits, keeping
+// the systemd cgroup non-empty and stalling container restart on
+// TimeoutStopSec. configurePiSysProcAttr gave pi its own pgid, so a
+// negative-pid kill reaches the whole tree.
 func (p *PiProcess) Kill() {
 	if p.cmd.Process == nil {
 		return
 	}
 
+	pid := p.cmd.Process.Pid
+
 	_ = p.stdin.Close()
-	_ = p.cmd.Process.Signal(os.Interrupt)
+
+	killProcessTree(pid, syscall.SIGTERM)
 
 	select {
 	case <-p.done:
-		return
 	case <-time.After(5 * time.Second):
-		slog.Warn("pi: process did not exit after SIGINT, sending SIGKILL")
+		slog.Warn("pi: process group did not exit after SIGTERM, sending SIGKILL")
 
-		_ = p.cmd.Process.Kill()
+		killProcessTree(pid, syscall.SIGKILL)
+
 		<-p.done
 	}
+
+	// p.done only tracks the leader's Wait(); a grandchild that
+	// ignored SIGTERM may still be running. Belt-and-braces SIGKILL
+	// the group — ESRCH is the expected outcome when everything is
+	// already gone.
+	killProcessTree(pid, syscall.SIGKILL)
 }
 
 // IsAlive returns true if the pi process is still running.

--- a/pi_proc_linux.go
+++ b/pi_proc_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configurePiSysProcAttr puts pi in its own process group so Kill can
+// signal the whole tree, and sets Pdeathsig so pi (and via the pgid
+// kill, its children) cannot outlive opencrow even if Kill never runs
+// — e.g. main returns before the worker goroutine reaches stopPi, or
+// opencrow is SIGKILLed. Without this, leaked tool subprocesses keep
+// the systemd cgroup non-empty and container restart blocks on
+// TimeoutStopSec.
+func configurePiSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:   true,
+		Pdeathsig: syscall.SIGTERM,
+	}
+}
+
+// killProcessTree signals the entire process group. pid == pgid because
+// of Setpgid above; negative pid addresses the group. Errors are
+// discarded: ESRCH after the group is gone is the expected end state,
+// and there is no recovery for EPERM here.
+func killProcessTree(pid int, sig syscall.Signal) {
+	_ = syscall.Kill(-pid, sig)
+}

--- a/pi_proc_other.go
+++ b/pi_proc_other.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configurePiSysProcAttr: non-Linux builds get a new process group but
+// no Pdeathsig (Linux-only). Good enough for dev on darwin; production
+// runs in NixOS containers.
+func configurePiSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcessTree(pid int, sig syscall.Signal) {
+	_ = syscall.Kill(-pid, sig)
+}

--- a/testdata/fake-pi
+++ b/testdata/fake-pi
@@ -5,6 +5,16 @@ set -eu
 while IFS= read -r line; do
   case "$line" in
     *'"type":"prompt"'*|*'"type": "prompt"'*)
+      # When the prompt asks for it, fork a long-lived grandchild and
+      # record its PID so the test can verify stopPi reaps the whole
+      # process tree, not just the fake-pi leader. Mirrors real pi
+      # running a slow bash tool when shutdown arrives.
+      case "$line" in
+        *spawn-child*)
+          sleep 300 &
+          printf '%s' "$!" > "$OPENCROW_SESSION_DIR/child.pid"
+          ;;
+      esac
       printf '%s\n' '{"type":"response","command":"prompt","success":true}'
       printf '%s\n' '{"type":"agent_start"}'
       printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"ok"}],"stopReason":"end_turn"}]}'

--- a/worker_test.go
+++ b/worker_test.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -96,5 +100,64 @@ func TestWorker_PiSurvivesItemContext(t *testing.T) {
 
 	if cr.Summary != "s" || cr.TokensBefore != 1 {
 		t.Fatalf("compact result = %+v", cr)
+	}
+}
+
+// Regression for slow container restarts after 0f1495a: that commit
+// moved pi off the per-item context (correct) onto context.Background,
+// removing the only thing that force-killed the process tree on
+// shutdown. Kill() sent SIGINT/SIGKILL to the pi leader only, so any
+// tool subprocess pi had forked (bash, curl, nix build…) was orphaned
+// and reparented to init. systemd then waited TimeoutStopSec (90s) for
+// the cgroup to empty before SIGKILLing it.
+//
+// fake-pi's "spawn-child" prompt forks a `sleep 300` grandchild and
+// writes its PID; the test asserts stopPi reaps it.
+func TestWorker_StopPiKillsProcessTree(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	_, _, err := w.sendWithRetry(t.Context(), "spawn-child")
+	if err != nil {
+		t.Fatalf("sendWithRetry: %v", err)
+	}
+
+	pidBytes, err := os.ReadFile(filepath.Join(w.piCfg.SessionDir, "child.pid"))
+	if err != nil {
+		t.Fatalf("reading child.pid (fake-pi should have written it): %v", err)
+	}
+
+	pid, err := strconv.Atoi(string(pidBytes))
+	if err != nil || pid <= 0 {
+		t.Fatalf("child.pid = %q", pidBytes)
+	}
+
+	// Sanity: grandchild is alive before shutdown.
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("grandchild %d not running before stopPi: %v", pid, err)
+	}
+
+	w.stopPi()
+
+	// Kill() escalates to SIGKILL after 5s; allow a little slack for
+	// the kernel to reap. Poll instead of sleeping the full window so
+	// the happy path stays fast.
+	deadline := time.Now().Add(6 * time.Second)
+
+	for {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			// Don't leak the sleep into the test runner.
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			t.Fatalf("grandchild %d still alive after stopPi; "+
+				"pi process tree leaks on shutdown (kill(pid,0) = %v)", pid, err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
0f1495a correctly detached pi from the per-item context but in doing so removed the only thing that force-killed the process on shutdown. Kill() only ever signalled the pi leader, and main fired Worker.Run in a goroutine it never joined, so os.Exit routinely won the race against stopPi. The result was pi and whatever bash/curl/nix tool call it had forked getting reparented to init, keeping the container cgroup non-empty until systemd hit TimeoutStopSec (90s) and SIGKILLed it.

Give pi its own process group (plus Pdeathsig on Linux as a backstop for the cases where Kill never runs at all) and have Kill signal the group, with a trailing SIGKILL sweep after the leader is reaped for grandchildren that ignored SIGTERM. In main, cancel and join the worker before Close/exit so the graceful path actually executes.

The fake-pi stub grows a spawn-child prompt that forks a long sleep and records its PID; the new test asserts stopPi reaps it.

Fixes: 0f1495a ("pi: decouple process lifetime from per-prompt context")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shutdown hanging issues when the backend exits unexpectedly.
  * Improved process termination to properly clean up child processes across all platforms.
  * Enhanced error handling and exit code reporting during shutdown.

* **Tests**
  * Added regression test for process tree cleanup validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->