### PR TITLE
sediment: 0.5.0-unstable-2026-02-14 -> 0.5.1

### DIFF
--- a/nix/sediment/default.nix
+++ b/nix/sediment/default.nix
@@ -5,20 +5,18 @@
   protobuf,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "sediment";
-  version = "0.5.0-unstable-2026-02-14";
+  version = "0.5.1";
 
-  # TODO: switch back to rendro/sediment once
-  # https://github.com/rendro/sediment/pull/60 is merged.
   src = fetchFromGitHub {
-    owner = "Mic92";
+    owner = "rendro";
     repo = "sediment";
-    rev = "392158db48334bee646a2fb2d10d63465f9d02c2";
-    hash = "sha256-29IuEF7RqjTlJwkf7hMB28fllUquadgQNwKq81icVlc=";
+    tag = "v${version}";
+    hash = "sha256-hINSwWJE9/Nq5QT2Y7vgFlrwz4fGVYhT4f98Eb7CS2c=";
   };
 
-  cargoHash = "sha256-6POb6FkDItoICpn/Q55XZr2LPOj3KBL2DrQMJCLcpJQ=";
+  cargoHash = "sha256-NfXChnMYyNyyT3ocdT65Ic6Iu3Zp0LtuTR/Je8FzqZc=";
 
   nativeBuildInputs = [ protobuf ];
 


### PR DESCRIPTION
Switch back to upstream rendro/sediment now that the Cargo.lock PR (rendro/sediment#60) has been merged and a tagged release is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.5.1 from unstable release
  * Updated source repository and build dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->