### PR TITLE
feat: add socket backend for local use

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,15 +16,22 @@ const (
 	backendMatrix = "matrix"
 	backendNostr  = "nostr"
 	backendSignal = "signal"
+	backendSocket = "socket"
 )
 
 type Config struct {
-	BackendType string // backendMatrix, backendNostr, or backendSignal
+	BackendType string // backendMatrix, backendNostr, backendSignal, or backendSocket
 	Matrix      MatrixConfig
 	Nostr       NostrConfig
 	Signal      SignalConfig
+	Socket      SocketConfig
 	Pi          PiConfig
 	Heartbeat   HeartbeatConfig
+}
+
+type SocketConfig struct {
+	SocketPath string
+	Name       string
 }
 
 type HeartbeatConfig struct {
@@ -95,10 +102,10 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 	backendType := env.or("OPENCROW_BACKEND", backendMatrix)
 
 	switch backendType {
-	case backendMatrix, backendNostr, backendSignal:
+	case backendMatrix, backendNostr, backendSignal, backendSocket:
 		// valid
 	default:
-		return nil, fmt.Errorf("OPENCROW_BACKEND=%q is not supported (valid: matrix, nostr, signal)", backendType)
+		return nil, fmt.Errorf("OPENCROW_BACKEND=%q is not supported (valid: matrix, nostr, signal, socket)", backendType)
 	}
 
 	idleTimeout, err := env.duration("OPENCROW_PI_IDLE_TIMEOUT", 30*time.Minute)
@@ -127,6 +134,10 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 			CryptoDBPath: env.or("OPENCROW_MATRIX_CRYPTO_DB", filepath.Join(workingDir, "crypto.db")),
 		},
 		Signal: loadSignalConfig(env, workingDir, allowedUsers),
+		Socket: SocketConfig{
+			SocketPath: env.or("OPENCROW_SOCKET_PATH", filepath.Join(workingDir, "sessions", "chat.sock")),
+			Name:       env.or("OPENCROW_SOCKET_NAME", "OpenCrow"),
+		},
 		Pi: PiConfig{
 			BinaryPath:    env.or("OPENCROW_PI_BINARY", "pi"),
 			SessionDir:    env.or("OPENCROW_PI_SESSION_DIR", "/var/lib/opencrow/sessions"),
@@ -165,6 +176,8 @@ func (cfg *Config) validateBackend(env envReader) error {
 		cfg.Nostr = nostrCfg
 	case backendSignal:
 		return cfg.Signal.validate()
+	case backendSocket:
+		// socket has sensible defaults, no validation needed
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -199,6 +199,50 @@ func TestNostrConfig_AllowedUsersNpubDecoding(t *testing.T) {
 	}
 }
 
+func TestSocketConfig_Defaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadConfig(testEnv(map[string]string{
+		"OPENCROW_BACKEND": "socket",
+	}))
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.BackendType != backendSocket {
+		t.Errorf("BackendType = %q, want %q", cfg.BackendType, backendSocket)
+	}
+
+	if cfg.Socket.SocketPath == "" {
+		t.Error("Socket.SocketPath should have a default")
+	}
+
+	if cfg.Socket.Name != "OpenCrow" {
+		t.Errorf("Socket.Name = %q, want OpenCrow", cfg.Socket.Name)
+	}
+}
+
+func TestSocketConfig_CustomValues(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadConfig(testEnv(map[string]string{
+		"OPENCROW_BACKEND":     "socket",
+		"OPENCROW_SOCKET_PATH": "/tmp/custom.sock",
+		"OPENCROW_SOCKET_NAME": "MyBot",
+	}))
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.Socket.SocketPath != "/tmp/custom.sock" {
+		t.Errorf("SocketPath = %q, want /tmp/custom.sock", cfg.Socket.SocketPath)
+	}
+
+	if cfg.Socket.Name != "MyBot" {
+		t.Errorf("Name = %q, want MyBot", cfg.Socket.Name)
+	}
+}
+
 func TestDiscoverSkills_Symlinks(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pinpox/opencrow/matrix"
 	nostrbackend "github.com/pinpox/opencrow/nostr"
 	signalbackend "github.com/pinpox/opencrow/signal"
+	socketbackend "github.com/pinpox/opencrow/socket"
 	// Register the pure-Go SQLite driver.
 	_ "modernc.org/sqlite"
 )
@@ -228,6 +229,8 @@ func createBackend(ctx context.Context, cfg *Config, handler backend.MessageHand
 		return createNostrBackend(ctx, cfg, handler)
 	case backendSignal:
 		return createSignalBackend(cfg, handler)
+	case backendSocket:
+		return createSocketBackend(cfg, handler)
 	default:
 		return nil, fmt.Errorf("unsupported backend type: %q", cfg.BackendType)
 	}
@@ -303,6 +306,18 @@ func createNostrBackend(ctx context.Context, cfg *Config, handler backend.Messag
 	b, err := nostrbackend.NewBackend(ctx, nostrCfg, handler)
 	if err != nil {
 		return nil, fmt.Errorf("creating nostr backend: %w", err)
+	}
+
+	return b, nil
+}
+
+func createSocketBackend(cfg *Config, handler backend.MessageHandler) (*socketbackend.Backend, error) {
+	b, err := socketbackend.New(socketbackend.Config{
+		SocketPath: cfg.Socket.SocketPath,
+		Name:       cfg.Socket.Name,
+	}, handler)
+	if err != nil {
+		return nil, fmt.Errorf("creating socket backend: %w", err)
 	}
 
 	return b, nil

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -196,6 +196,7 @@ let
                 "matrix"
                 "nostr"
                 "signal"
+                "socket"
               ];
               default = "matrix";
               description = "Messaging backend to use.";

--- a/socket/backend.go
+++ b/socket/backend.go
@@ -1,0 +1,410 @@
+// Package socket implements the Backend interface over a local UNIX socket.
+//
+// The protocol is NDJSON, compatible with nostr-chatd so existing clients
+// (noctalia nostr-chat plugin, opencrow-send CLI) work without changes.
+//
+// Since client and server share a filesystem (via the bind-mounted state
+// dir), file transfers are just path references — no upload needed.
+package socket
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pinpox/opencrow/backend"
+)
+
+// Config holds socket backend configuration.
+type Config struct {
+	SocketPath string // path to the UNIX socket
+	Name       string // display name for status events
+}
+
+// --- Wire protocol (nostr-chatd compatible) ---
+
+type eventKind string
+
+const (
+	evStatus eventKind = "status"
+	evMsg    eventKind = "msg"
+	evSent   eventKind = "sent"
+	evAck    eventKind = "ack"
+	evImg    eventKind = "img"
+	evError  eventKind = "error"
+)
+
+type dir string
+
+const (
+	dirIn  dir = "in"
+	dirOut dir = "out"
+)
+
+type msgState string
+
+const (
+	stateSent msgState = "sent"
+)
+
+// Wire types use camelCase JSON tags to match the nostr-chatd protocol.
+//
+//nolint:tagliatelle // protocol compatibility with nostr-chatd
+type event struct {
+	Kind        eventKind `json:"kind"`
+	Msg         *message  `json:"msg,omitempty"`
+	Target      string    `json:"target,omitempty"`
+	Mark        string    `json:"mark,omitempty"`
+	Image       string    `json:"image,omitempty"`
+	State       msgState  `json:"state,omitempty"`
+	Streaming   bool      `json:"streaming"`
+	RelaysUp    int       `json:"relaysUp"`
+	RelaysTotal int       `json:"relaysTotal,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Unread      int       `json:"unread,omitempty"`
+	Text        string    `json:"text,omitempty"`
+}
+
+//nolint:tagliatelle // protocol compatibility with nostr-chatd
+type message struct {
+	ID      string   `json:"id"`
+	PubKey  string   `json:"pubkey"`
+	Content string   `json:"content"`
+	TS      int64    `json:"ts"`
+	Dir     dir      `json:"dir"`
+	Ack     string   `json:"ack"`
+	Read    bool     `json:"read"`
+	Image   string   `json:"image,omitempty"`
+	ReplyTo string   `json:"replyTo,omitempty"`
+	State   msgState `json:"state"`
+}
+
+type cmdName string
+
+const (
+	cmdSend     cmdName = "send"
+	cmdSendFile cmdName = "send-file"
+	cmdReplay   cmdName = "replay"
+	cmdMarkRead cmdName = "mark-read"
+)
+
+//nolint:tagliatelle // protocol compatibility with nostr-chatd
+type command struct {
+	Cmd     cmdName `json:"cmd"`
+	Text    string  `json:"text,omitempty"`
+	ReplyTo string  `json:"replyTo,omitempty"`
+	Path    string  `json:"path,omitempty"`
+	N       int     `json:"n,omitempty"`
+}
+
+// --- Backend implementation ---
+
+const conversationID = "local"
+
+// Backend implements backend.Backend over a local UNIX socket.
+type Backend struct {
+	cfg     Config
+	handler backend.MessageHandler
+
+	cancel backend.Canceler
+
+	mu    sync.Mutex
+	conns map[net.Conn]struct{}
+
+	msgSeq atomic.Int64
+}
+
+// New creates a new socket backend.
+func New(cfg Config, handler backend.MessageHandler) (*Backend, error) {
+	if cfg.SocketPath == "" {
+		return nil, errors.New("socket path is required")
+	}
+
+	if cfg.Name == "" {
+		cfg.Name = "OpenCrow"
+	}
+
+	return &Backend{
+		cfg:     cfg,
+		handler: handler,
+		conns:   make(map[net.Conn]struct{}),
+	}, nil
+}
+
+// Run listens on the UNIX socket and dispatches commands. Blocks until ctx is cancelled.
+func (b *Backend) Run(ctx context.Context) error {
+	_ = os.Remove(b.cfg.SocketPath)
+
+	if err := os.MkdirAll(filepath.Dir(b.cfg.SocketPath), 0o755); err != nil {
+		return fmt.Errorf("creating socket parent dir: %w", err)
+	}
+
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(ctx, "unix", b.cfg.SocketPath)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", b.cfg.SocketPath, err)
+	}
+
+	// Make socket world-accessible so the host user can connect
+	// through the bind-mounted state dir.
+	if err := os.Chmod(b.cfg.SocketPath, 0o666); err != nil {
+		slog.Warn("socket: chmod failed", "error", err)
+	}
+
+	slog.Info("socket: listening", "path", b.cfg.SocketPath)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	b.cancel.Set(cancel)
+	defer b.cancel.Set(nil)
+
+	go func() { <-runCtx.Done(); ln.Close() }()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if runCtx.Err() != nil {
+				return nil
+			}
+
+			slog.Warn("socket: accept error", "error", err)
+
+			continue
+		}
+
+		b.mu.Lock()
+		b.conns[conn] = struct{}{}
+		b.mu.Unlock()
+
+		go b.handleConn(runCtx, conn)
+	}
+}
+
+// Stop signals the backend to shut down.
+func (b *Backend) Stop() {
+	b.cancel.Cancel()
+}
+
+// Close releases resources.
+func (b *Backend) Close() error {
+	return nil
+}
+
+// SendMessage sends a text reply to connected clients.
+func (b *Backend) SendMessage(_ context.Context, _ string, text string, replyToID string) string {
+	id := b.nextID()
+
+	b.push(event{
+		Kind:      evMsg,
+		Streaming: true,
+		Msg: &message{
+			ID:      id,
+			Content: text,
+			TS:      time.Now().Unix(),
+			Dir:     dirIn, // "in" from the client's perspective (bot → client)
+			State:   stateSent,
+			ReplyTo: replyToID,
+		},
+	})
+
+	return id
+}
+
+// SendFile sends a file path reference to connected clients.
+func (b *Backend) SendFile(_ context.Context, _ string, filePath string) error {
+	id := b.nextID()
+
+	b.push(event{
+		Kind:      evMsg,
+		Streaming: true,
+		Msg: &message{
+			ID:      id,
+			Content: "",
+			TS:      time.Now().Unix(),
+			Dir:     dirIn,
+			State:   stateSent,
+			Image:   filePath,
+		},
+	})
+
+	return nil
+}
+
+// SetTyping pushes a typing status event.
+func (b *Backend) SetTyping(_ context.Context, _ string, typing bool) {
+	// nostr-chatd protocol doesn't have a typing event.
+	// We could add one, but existing clients ignore unknown kinds gracefully.
+	if typing {
+		b.push(event{Kind: "typing", Streaming: true})
+	}
+}
+
+// ResetConversation is a no-op for the socket backend (single conversation).
+func (b *Backend) ResetConversation(_ context.Context, _ string) {}
+
+// SystemPromptExtra returns socket-specific system prompt additions.
+func (b *Backend) SystemPromptExtra() string {
+	return ""
+}
+
+// MarkdownFlavor reports full Markdown support (local clients typically render it).
+func (b *Backend) MarkdownFlavor() backend.MarkdownFlavor {
+	return backend.MarkdownFull
+}
+
+// --- Internal ---
+
+func (b *Backend) handleConn(ctx context.Context, conn net.Conn) {
+	defer func() {
+		b.mu.Lock()
+		delete(b.conns, conn)
+		b.mu.Unlock()
+		conn.Close()
+	}()
+
+	sc := bufio.NewScanner(conn)
+
+	for sc.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+
+		var cmd command
+		if err := json.Unmarshal(sc.Bytes(), &cmd); err != nil {
+			slog.Warn("socket: bad command", "raw", sc.Text(), "error", err)
+
+			continue
+		}
+
+		b.handleCommand(ctx, cmd, conn)
+	}
+}
+
+func (b *Backend) handleCommand(ctx context.Context, cmd command, conn net.Conn) {
+	switch cmd.Cmd {
+	case cmdSend:
+		b.handleSend(ctx, cmd)
+	case cmdSendFile:
+		b.handleSendFile(ctx, cmd)
+	case cmdReplay:
+		b.pushTo(conn, event{
+			Kind:        evStatus,
+			Streaming:   true,
+			RelaysUp:    1,
+			RelaysTotal: 1,
+			Name:        b.cfg.Name,
+		})
+	case cmdMarkRead:
+		// No-op for local backend.
+	default:
+		slog.Warn("socket: unknown command", "cmd", cmd.Cmd)
+	}
+}
+
+func (b *Backend) handleSend(ctx context.Context, cmd command) {
+	if cmd.Text == "" {
+		return
+	}
+
+	id := b.nextID()
+
+	b.push(event{
+		Kind:      evMsg,
+		Streaming: true,
+		Msg: &message{
+			ID:      id,
+			Content: cmd.Text,
+			TS:      time.Now().Unix(),
+			Dir:     dirOut,
+			State:   stateSent,
+			ReplyTo: cmd.ReplyTo,
+		},
+	})
+
+	b.handler(ctx, backend.Message{
+		ConversationID: conversationID,
+		SenderID:       "local",
+		Text:           cmd.Text,
+		MessageID:      id,
+		ReplyToID:      cmd.ReplyTo,
+	})
+}
+
+func (b *Backend) handleSendFile(ctx context.Context, cmd command) {
+	if cmd.Path == "" {
+		return
+	}
+
+	id := b.nextID()
+
+	b.push(event{
+		Kind:      evMsg,
+		Streaming: true,
+		Msg: &message{
+			ID:    id,
+			TS:    time.Now().Unix(),
+			Dir:   dirOut,
+			State: stateSent,
+			Image: cmd.Path,
+		},
+	})
+
+	b.handler(ctx, backend.Message{
+		ConversationID: conversationID,
+		SenderID:       "local",
+		Text:           backend.AttachmentText("", cmd.Path),
+		MessageID:      id,
+	})
+}
+
+func (b *Backend) push(ev event) {
+	line, err := json.Marshal(ev)
+	if err != nil {
+		slog.Error("socket: marshal failed", "error", err)
+
+		return
+	}
+
+	line = append(line, '\n')
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for c := range b.conns {
+		if _, werr := c.Write(line); werr != nil {
+			delete(b.conns, c)
+			c.Close()
+		}
+	}
+}
+
+func (b *Backend) pushTo(conn net.Conn, ev event) {
+	line, err := json.Marshal(ev)
+	if err != nil {
+		slog.Error("socket: marshal failed", "error", err)
+
+		return
+	}
+
+	line = append(line, '\n')
+
+	if _, err := conn.Write(line); err != nil {
+		slog.Warn("socket: write failed", "error", err)
+	}
+}
+
+func (b *Backend) nextID() string {
+	return "local-" + strconv.FormatInt(b.msgSeq.Add(1), 10)
+}

--- a/socket/backend_test.go
+++ b/socket/backend_test.go
@@ -1,0 +1,320 @@
+package socket
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pinpox/opencrow/backend"
+)
+
+func TestNew_RequiresSocketPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(Config{}, func(_ context.Context, _ backend.Message) {})
+	if err == nil {
+		t.Fatal("expected error for empty SocketPath")
+	}
+}
+
+func TestNew_DefaultName(t *testing.T) {
+	t.Parallel()
+
+	b, err := New(Config{SocketPath: "/tmp/test.sock"}, func(_ context.Context, _ backend.Message) {})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if b.cfg.Name != "OpenCrow" {
+		t.Errorf("Name = %q, want OpenCrow", b.cfg.Name)
+	}
+}
+
+// startBackend starts a socket backend in a goroutine, returning the
+// backend and a cleanup function. The socket is created in t.TempDir().
+func startBackend(t *testing.T, handler backend.MessageHandler) (*Backend, string, context.CancelFunc) {
+	t.Helper()
+
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	b, err := New(Config{SocketPath: sockPath, Name: "TestBot"}, handler)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		_ = b.Run(ctx)
+	}()
+
+	// Wait for socket to appear.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var d net.Dialer
+		if conn, err := d.DialContext(context.Background(), "unix", sockPath); err == nil {
+			conn.Close()
+
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return b, sockPath, cancel
+}
+
+func dial(t *testing.T, sockPath string) net.Conn {
+	t.Helper()
+
+	var d net.Dialer
+
+	conn, err := d.DialContext(context.Background(), "unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	return conn
+}
+
+func readEvent(t *testing.T, conn net.Conn) event {
+	t.Helper()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	buf := make([]byte, 4096)
+
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var ev event
+	if err := json.Unmarshal(buf[:n], &ev); err != nil {
+		t.Fatalf("unmarshal event: %v (raw: %s)", err, buf[:n])
+	}
+
+	return ev
+}
+
+func sendCommand(t *testing.T, conn net.Conn, cmd command) {
+	t.Helper()
+
+	line, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	line = append(line, '\n')
+
+	if _, err := conn.Write(line); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestReplay_ReturnsStatus(t *testing.T) {
+	t.Parallel()
+
+	_, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdReplay})
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evStatus {
+		t.Fatalf("Kind = %q, want %q", ev.Kind, evStatus)
+	}
+
+	if ev.Name != "TestBot" {
+		t.Errorf("Name = %q, want TestBot", ev.Name)
+	}
+
+	if !ev.Streaming {
+		t.Error("Streaming should be true")
+	}
+}
+
+func TestSend_DeliversToHandler(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		received []backend.Message
+	)
+
+	handler := func(_ context.Context, msg backend.Message) {
+		mu.Lock()
+
+		received = append(received, msg)
+
+		mu.Unlock()
+	}
+
+	_, sockPath, cancel := startBackend(t, handler)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdSend, Text: "hello"})
+
+	// Read the echo event (outgoing message).
+	ev := readEvent(t, conn)
+	if ev.Kind != evMsg {
+		t.Fatalf("Kind = %q, want %q", ev.Kind, evMsg)
+	}
+
+	if ev.Msg.Dir != dirOut {
+		t.Errorf("Dir = %q, want %q", ev.Msg.Dir, dirOut)
+	}
+
+	if ev.Msg.Content != "hello" {
+		t.Errorf("Content = %q, want hello", ev.Msg.Content)
+	}
+
+	// Check handler received the message.
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) != 1 {
+		t.Fatalf("handler got %d messages, want 1", len(received))
+	}
+
+	if received[0].Text != "hello" {
+		t.Errorf("handler Text = %q, want hello", received[0].Text)
+	}
+
+	if received[0].ConversationID != conversationID {
+		t.Errorf("ConversationID = %q, want %q", received[0].ConversationID, conversationID)
+	}
+}
+
+func TestSend_EmptyTextIgnored(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	handler := func(_ context.Context, _ backend.Message) {
+		called = true
+	}
+
+	_, sockPath, cancel := startBackend(t, handler)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdSend, Text: ""})
+	time.Sleep(50 * time.Millisecond)
+
+	if called {
+		t.Error("handler should not be called for empty text")
+	}
+}
+
+func TestSendMessage_PushesToClients(t *testing.T) {
+	t.Parallel()
+
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	// SendMessage from the backend side (simulating a bot reply).
+	id := b.SendMessage(context.Background(), "local", "bot reply", "")
+
+	if id == "" {
+		t.Fatal("SendMessage returned empty id")
+	}
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evMsg {
+		t.Fatalf("Kind = %q, want %q", ev.Kind, evMsg)
+	}
+
+	if ev.Msg.Dir != dirIn {
+		t.Errorf("Dir = %q, want %q", ev.Msg.Dir, dirIn)
+	}
+
+	if ev.Msg.Content != "bot reply" {
+		t.Errorf("Content = %q, want 'bot reply'", ev.Msg.Content)
+	}
+}
+
+func TestSendFile_PushesImageEvent(t *testing.T) {
+	t.Parallel()
+
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	err := b.SendFile(context.Background(), "local", "/tmp/chart.png")
+	if err != nil {
+		t.Fatalf("SendFile: %v", err)
+	}
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evMsg {
+		t.Fatalf("Kind = %q, want %q", ev.Kind, evMsg)
+	}
+
+	if ev.Msg.Image != "/tmp/chart.png" {
+		t.Errorf("Image = %q, want /tmp/chart.png", ev.Msg.Image)
+	}
+}
+
+func TestSendFile_Command(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		received []backend.Message
+	)
+
+	handler := func(_ context.Context, msg backend.Message) {
+		mu.Lock()
+
+		received = append(received, msg)
+
+		mu.Unlock()
+	}
+
+	_, sockPath, cancel := startBackend(t, handler)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdSendFile, Path: "/tmp/photo.jpg"})
+
+	// Read the echo event.
+	ev := readEvent(t, conn)
+	if ev.Msg.Image != "/tmp/photo.jpg" {
+		t.Errorf("Image = %q, want /tmp/photo.jpg", ev.Msg.Image)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) != 1 {
+		t.Fatalf("handler got %d messages, want 1", len(received))
+	}
+
+	if received[0].Text == "" {
+		t.Error("handler Text should contain attachment text")
+	}
+}


### PR DESCRIPTION
Add a new "socket" backend that listens on a UNIX socket and speaks NDJSON (compatible with the nostr-chatd protocol). This enables local deployments where client and server run on the same machine without needing a nostr relay, key management, or a bridge daemon.

- New package socket/ implementing backend.Backend over a UNIX socket
- Config via OPENCROW_BACKEND=socket, OPENCROW_SOCKET_PATH, OPENCROW_SOCKET_NAME
- Files transferred as local paths (no upload needed)
- NixOS module updated to accept "socket" as valid backend type
- Protocol compatible with noctalia nostr-chat plugin and opencrow-send CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a socket backend option for the system, configurable via environment variables for socket path and name
  * Socket backend supports message exchange, file transfers, and typing indicators

* **Tests**
  * Added comprehensive test coverage for socket backend configuration and operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->