### PR TITLE
feat: stream text deltas to clients during generation

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -61,5 +61,14 @@ type Message struct {
 	ReplyToID      string // backend-specific ID of the message being replied to (empty if not a reply)
 }
 
+// Streamer is an optional interface backends can implement to support
+// streaming text deltas during generation. Backends that don't implement
+// this fall back to buffered SendMessage.
+type Streamer interface {
+	// SendDelta sends an incremental text fragment for an in-progress message.
+	// messageID identifies the message being built (same across all deltas).
+	SendDelta(ctx context.Context, conversationID string, messageID string, delta string)
+}
+
 // MessageHandler is a callback invoked by the backend for each inbound user message.
 type MessageHandler func(ctx context.Context, msg Message)

--- a/pi_rpc.go
+++ b/pi_rpc.go
@@ -56,6 +56,15 @@ type rpcEvent struct {
 	// extension_error fields
 	ExtensionPath string `json:"extensionPath,omitempty"` //nolint:tagliatelle // pi protocol uses camelCase
 	Event         string `json:"event,omitempty"`
+
+	// message_update fields — camelCase is dictated by the pi protocol.
+	AssistantMessageEvent *assistantMessageEvent `json:"assistantMessageEvent,omitempty"` //nolint:tagliatelle // pi protocol uses camelCase
+}
+
+// assistantMessageEvent is the streaming delta payload inside a message_update event.
+type assistantMessageEvent struct {
+	Type  string `json:"type"`            // "text_delta", "thinking_delta", "text_start", etc.
+	Delta string `json:"delta,omitempty"` // incremental text content
 }
 
 // CompactResult holds the data returned by a successful compact command.
@@ -112,7 +121,8 @@ func (p *PiProcess) Compact(ctx context.Context) (*CompactResult, error) {
 // The caller must ensure only one goroutine calls this at a time.
 // If ctx is cancelled, an abort command is sent to pi and the response
 // is drained before returning.
-func (p *PiProcess) sendAndWait(ctx context.Context, message string) (string, error) {
+// onDelta, if non-nil, is called with each text delta during generation.
+func (p *PiProcess) sendAndWait(ctx context.Context, message string, onDelta func(string)) (string, error) {
 	if !p.IsAlive() {
 		return "", errors.New("pi process is not alive")
 	}
@@ -121,7 +131,7 @@ func (p *PiProcess) sendAndWait(ctx context.Context, message string) (string, er
 		return "", err
 	}
 
-	return p.waitForResult(ctx)
+	return p.waitForResult(ctx, onDelta)
 }
 
 func (p *PiProcess) sendCommand(cmd any) error {
@@ -288,6 +298,7 @@ func (p *PiProcess) handleSideEffects(evt rpcEvent) error {
 type resultWaiter struct {
 	reply    string
 	finalErr string
+	onDelta  func(string) // called with each text delta during generation
 }
 
 // continuesTurn returns true for events that mean pi is still working
@@ -308,6 +319,13 @@ func (w *resultWaiter) handle(evt rpcEvent) (bool, error) {
 			w.finalErr = evt.FinalError
 
 			return true, nil
+		}
+
+	case rpcTypeMessageUpdate:
+		if w.onDelta != nil && evt.AssistantMessageEvent != nil &&
+			evt.AssistantMessageEvent.Type == "text_delta" &&
+			evt.AssistantMessageEvent.Delta != "" {
+			w.onDelta(evt.AssistantMessageEvent.Delta)
 		}
 
 	case rpcTypeAgentEnd:
@@ -381,8 +399,10 @@ func (w *resultWaiter) handleAgentEnd(evt rpcEvent) {
 // perceptible latency to the rare "pi gave up and went idle" path.
 const errGraceWindow = 200 * time.Millisecond
 
-func (p *PiProcess) waitForResult(ctx context.Context) (string, error) {
+func (p *PiProcess) waitForResult(ctx context.Context, onDelta func(string)) (string, error) {
 	var w resultWaiter
+
+	w.onDelta = onDelta
 
 	// The loop may run more than once: drainEvents returns when
 	// handle() says "done", but an error agent_end is only

--- a/pi_test.go
+++ b/pi_test.go
@@ -108,7 +108,7 @@ func TestWaitForResult_RetryRescindsError(t *testing.T) {
 		ch <- rpcParsed{event: e}
 	}
 
-	reply, err := p.waitForResult(t.Context())
+	reply, err := p.waitForResult(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("waitForResult: %v", err)
 	}

--- a/socket/backend.go
+++ b/socket/backend.go
@@ -222,6 +222,16 @@ func (b *Backend) SendMessage(_ context.Context, _ string, text string, replyToI
 	return id
 }
 
+// SendDelta sends an incremental text fragment for a streaming message.
+func (b *Backend) SendDelta(_ context.Context, _ string, messageID string, delta string) {
+	b.push(event{
+		Kind:      "delta",
+		Streaming: true,
+		Target:    messageID,
+		Text:      delta,
+	})
+}
+
 // SendFile sends a file path reference to connected clients.
 func (b *Backend) SendFile(_ context.Context, _ string, filePath string) error {
 	id := b.nextID()

--- a/socket/backend_test.go
+++ b/socket/backend_test.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"net"
@@ -81,24 +82,38 @@ func dial(t *testing.T, sockPath string) net.Conn {
 	return conn
 }
 
-func readEvent(t *testing.T, conn net.Conn) event {
+// connScanner wraps a net.Conn with a bufio.Scanner for NDJSON reading.
+// Reuse across readEvent calls to avoid losing buffered data.
+type connScanner struct {
+	sc *bufio.Scanner
+}
+
+func newConnScanner(conn net.Conn) *connScanner {
+	return &connScanner{sc: bufio.NewScanner(conn)}
+}
+
+func (cs *connScanner) readEvent(t *testing.T, conn net.Conn) event {
 	t.Helper()
 
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 
-	buf := make([]byte, 4096)
-
-	n, err := conn.Read(buf)
-	if err != nil {
-		t.Fatalf("read: %v", err)
+	if !cs.sc.Scan() {
+		t.Fatalf("read: %v", cs.sc.Err())
 	}
 
 	var ev event
-	if err := json.Unmarshal(buf[:n], &ev); err != nil {
-		t.Fatalf("unmarshal event: %v (raw: %s)", err, buf[:n])
+	if err := json.Unmarshal(cs.sc.Bytes(), &ev); err != nil {
+		t.Fatalf("unmarshal event: %v (raw: %s)", err, cs.sc.Text())
 	}
 
 	return ev
+}
+
+// readEvent is a convenience wrapper for tests that only read one event.
+func readEvent(t *testing.T, conn net.Conn) event {
+	t.Helper()
+
+	return newConnScanner(conn).readEvent(t, conn)
 }
 
 func sendCommand(t *testing.T, conn net.Conn, cmd command) {
@@ -317,4 +332,48 @@ func TestSendFile_Command(t *testing.T) {
 	if received[0].Text == "" {
 		t.Error("handler Text should contain attachment text")
 	}
+}
+
+func TestSendDelta_StreamsToClients(t *testing.T) {
+	t.Parallel()
+
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	cs := newConnScanner(conn)
+
+	// Send two deltas.
+	b.SendDelta(context.Background(), "local", "stream-1", "Hello")
+	b.SendDelta(context.Background(), "local", "stream-1", " world")
+
+	ev1 := cs.readEvent(t, conn)
+	if ev1.Kind != "delta" {
+		t.Fatalf("Kind = %q, want delta", ev1.Kind)
+	}
+
+	if ev1.Target != "stream-1" {
+		t.Errorf("Target = %q, want stream-1", ev1.Target)
+	}
+
+	if ev1.Text != "Hello" {
+		t.Errorf("Text = %q, want Hello", ev1.Text)
+	}
+
+	ev2 := cs.readEvent(t, conn)
+	if ev2.Text != " world" {
+		t.Errorf("Text = %q, want ' world'", ev2.Text)
+	}
+}
+
+func TestBackend_ImplementsStreamer(t *testing.T) {
+	t.Parallel()
+
+	b, _, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	defer cancel()
+
+	// Verify the socket backend implements backend.Streamer.
+	var _ backend.Streamer = b
 }

--- a/worker.go
+++ b/worker.go
@@ -355,7 +355,18 @@ func (w *Worker) processPrompt(ctx context.Context, item Inbox) bool {
 
 	taskStart := time.Now()
 
-	pi, reply, err := w.sendWithRetry(ctx, prompt)
+	// Stream text deltas to the client if the backend supports it.
+	var onDelta func(string)
+
+	if streamer, ok := w.be.(backend.Streamer); ok {
+		streamID := fmt.Sprintf("stream-%d", time.Now().UnixNano())
+
+		onDelta = func(delta string) {
+			streamer.SendDelta(ctx, convID, streamID, delta)
+		}
+	}
+
+	pi, reply, err := w.sendWithRetry(ctx, prompt, onDelta)
 	if err != nil {
 		killPi := pi != nil
 
@@ -487,13 +498,14 @@ func wasPreempted(ctx context.Context, err error) bool {
 
 // sendWithRetry sends a prompt to pi, retrying once with a fresh
 // process if the first attempt fails due to a stale/crashed process.
-func (w *Worker) sendWithRetry(ctx context.Context, prompt string) (*PiProcess, string, error) {
+// onDelta, if non-nil, is called with each text delta during generation.
+func (w *Worker) sendWithRetry(ctx context.Context, prompt string, onDelta func(string)) (*PiProcess, string, error) {
 	pi, err := w.ensurePi(ctx)
 	if err != nil {
 		return nil, "", err
 	}
 
-	reply, err := pi.sendAndWait(ctx, prompt)
+	reply, err := pi.sendAndWait(ctx, prompt, onDelta)
 	if err == nil {
 		return pi, reply, nil
 	}
@@ -511,7 +523,7 @@ func (w *Worker) sendWithRetry(ctx context.Context, prompt string) (*PiProcess, 
 		return nil, "", err
 	}
 
-	reply, err = pi.sendAndWait(ctx, prompt)
+	reply, err = pi.sendAndWait(ctx, prompt, onDelta)
 
 	return pi, reply, err
 }
@@ -599,7 +611,7 @@ func (w *Worker) readHeartbeatFile() string {
 func (w *Worker) retryEmptyResponse(ctx context.Context, pi *PiProcess) string {
 	slog.Warn("worker: empty response, re-prompting for summary")
 
-	reply, err := pi.sendAndWait(ctx, "You just completed a task but your response contained no text for the user. Please briefly summarize what you did or respond to the user's message.")
+	reply, err := pi.sendAndWait(ctx, "You just completed a task but your response contained no text for the user. Please briefly summarize what you did or respond to the user's message.", nil)
 	if err != nil {
 		slog.Error("worker: re-prompt failed", "error", err)
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -63,7 +63,7 @@ func TestWorker_PiSurvivesItemContext(t *testing.T) {
 	// the prompt completes.
 	itemCtx, cancel := context.WithCancel(context.Background())
 
-	pi, reply, err := w.sendWithRetry(itemCtx, "hello")
+	pi, reply, err := w.sendWithRetry(itemCtx, "hello", nil)
 	if err != nil || reply != "ok" {
 		t.Fatalf("sendWithRetry = (%q, %v), want (ok, nil)", reply, err)
 	}
@@ -83,7 +83,7 @@ func TestWorker_PiSurvivesItemContext(t *testing.T) {
 	// A follow-up prompt must reuse the existing process, not respawn.
 	// On eve the dead process triggered sendWithRetry's "pi exited,
 	// starting fresh process" path on every message.
-	pi2, _, err := w.sendWithRetry(t.Context(), "again")
+	pi2, _, err := w.sendWithRetry(t.Context(), "again", nil)
 	if err != nil {
 		t.Fatalf("second sendWithRetry: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestWorker_StopPiKillsProcessTree(t *testing.T) {
 
 	w := newFakePiWorker(t)
 
-	_, _, err := w.sendWithRetry(t.Context(), "spawn-child")
+	_, _, err := w.sendWithRetry(t.Context(), "spawn-child", nil)
 	if err != nil {
 		t.Fatalf("sendWithRetry: %v", err)
 	}


### PR DESCRIPTION
Pi already emits message_update events with text_delta payloads during generation — opencrow was ignoring them. Now the worker forwards each delta to the backend in real time via a new optional Streamer interface.

- Parse assistantMessageEvent.text_delta from message_update RPC events
- Add onDelta callback to sendAndWait/waitForResult/sendWithRetry
- Add backend.Streamer interface (SendDelta method)
- Socket backend emits "delta" NDJSON events with incremental text
- Final "msg" event still carries the complete text for non-streaming clients and replay
- Backends that don't implement Streamer (nostr, matrix, signal) are unaffected — they continue to receive the full reply on completion
- Tests for delta streaming and Streamer interface conformance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming text delivery: Supported backends can now send incremental text updates as responses are generated in real-time, allowing users to see content appear progressively instead of waiting for the complete message to be buffered before display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->