### PR TITLE
Add model listing and switching

### DIFF
--- a/app.go
+++ b/app.go
@@ -63,17 +63,23 @@ func (a *App) HandleMessage(ctx context.Context, msg backend.Message) {
 	// Record the incoming message so future reply-to references can quote it.
 	a.outbox.Put(ctx, msg.ConversationID, msg.MessageID, msg.Text)
 
-	switch strings.TrimSpace(msg.Text) {
-	case "!help":
+	text := strings.TrimSpace(msg.Text)
+
+	switch {
+	case text == "!help":
 		a.handleHelp(ctx, msg)
-	case "!restart":
+	case text == "!restart":
 		a.handleRestart(ctx, msg)
-	case "!stop":
+	case text == "!stop":
 		a.handleStop(ctx, msg)
-	case "!compact":
+	case text == "!compact":
 		a.handleCompact(ctx, msg)
-	case "!skills":
+	case text == "!skills":
 		a.handleSkills(ctx, msg)
+	case text == "!models":
+		a.handleModels(ctx, msg)
+	case text == "!model" || strings.HasPrefix(text, "!model "):
+		a.handleModel(ctx, msg, strings.TrimSpace(strings.TrimPrefix(text, "!model")))
 	default:
 		a.handlePrompt(ctx, msg)
 	}
@@ -85,7 +91,9 @@ func (a *App) handleHelp(ctx context.Context, msg backend.Message) {
 		"  !restart — Kill the current session and start fresh\n" +
 		"  !stop    — Abort the currently running agent turn\n" +
 		"  !compact — Compact conversation context to reduce token usage\n" +
-		"  !skills  — List loaded skills"
+		"  !skills  — List loaded skills\n" +
+		"  !models  — List available models\n" +
+		"  !model <provider>/<id> — Switch to the given model"
 	a.backend.SendMessage(ctx, msg.ConversationID, help, "")
 }
 
@@ -130,6 +138,81 @@ func (a *App) handleCompact(ctx context.Context, msg backend.Message) {
 
 func (a *App) handleSkills(ctx context.Context, msg backend.Message) {
 	a.backend.SendMessage(ctx, msg.ConversationID, a.worker.SkillsSummary(), "")
+}
+
+// handleModels lists pi's configured models as a single text reply,
+// marking the active one with a leading asterisk. Works on any backend
+// because it only uses SendMessage; the socket backend additionally
+// exposes the same data as a structured 'models' event for its GUI.
+func (a *App) handleModels(ctx context.Context, msg backend.Message) {
+	models, err := a.worker.ListModels(ctx)
+	if err != nil {
+		a.backend.SendMessage(ctx, msg.ConversationID, fmt.Sprintf("Failed to list models: %v", err), "")
+
+		return
+	}
+
+	if len(models) == 0 {
+		a.backend.SendMessage(ctx, msg.ConversationID, "No models configured.", "")
+
+		return
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("Available models (* = active):\n")
+
+	for _, m := range models {
+		marker := "  "
+		if m.Active {
+			marker = "* "
+		}
+
+		fmt.Fprintf(&sb, "%s%s/%s\n", marker, m.Provider, m.ID)
+	}
+
+	a.backend.SendMessage(ctx, msg.ConversationID, strings.TrimRight(sb.String(), "\n"), "")
+}
+
+// handleModel switches pi to the requested model. arg is the substring
+// that followed "!model" with surrounding whitespace stripped; it is
+// required to be "<provider>/<id>". The slash form mirrors the protocol
+// shape (provider + modelId) and is unambiguous even when the same id
+// is registered under multiple providers.
+func (a *App) handleModel(ctx context.Context, msg backend.Message, arg string) {
+	if arg == "" {
+		a.backend.SendMessage(ctx, msg.ConversationID,
+			"Usage: !model <provider>/<id>. Use !models to list available models.", "")
+
+		return
+	}
+
+	provider, id, ok := strings.Cut(arg, "/")
+	if !ok || provider == "" || id == "" {
+		a.backend.SendMessage(ctx, msg.ConversationID,
+			"Invalid model spec. Use !model <provider>/<id> (e.g. !model openai/gpt-4).", "")
+
+		return
+	}
+
+	model, err := a.worker.SetModel(ctx, provider, id)
+	if err != nil {
+		a.backend.SendMessage(ctx, msg.ConversationID, fmt.Sprintf("Failed to set model: %v", err), "")
+
+		return
+	}
+
+	// Push the post-switch list to any GUI clients on this backend so
+	// their dropdowns reconcile without a manual reopen. Synchronous is
+	// fine: handleModel runs on a backend-handler goroutine, not the
+	// worker's drain loop, so BroadcastModels' inbox round-trip won't
+	// deadlock. Backends without a structured model UI (matrix, nostr,
+	// signal) don't implement modelsBroadcaster and the call is skipped.
+	if mb, ok := a.backend.(modelsBroadcaster); ok {
+		mb.BroadcastModels(ctx)
+	}
+
+	a.backend.SendMessage(ctx, msg.ConversationID, fmt.Sprintf("Model switched to %s/%s.", model.Provider, model.ID), "")
 }
 
 func (a *App) handlePrompt(ctx context.Context, msg backend.Message) {

--- a/app_test.go
+++ b/app_test.go
@@ -2,22 +2,27 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pinpox/opencrow/backend"
 )
 
 const testRoom = "!room1"
 
-// mockBackend records calls for testing.
+// mockBackend records calls for testing. It also implements
+// modelsBroadcaster so handlers that opportunistically push model
+// updates (handleModel) can be observed.
 type mockBackend struct {
 	mu                    sync.Mutex
 	sentMessages          []sentMessage
 	sentFiles             []sentFile
 	typingCalls           []typingCall
 	resetCalls            []string
+	broadcastCtxs         []context.Context
 	systemPromptExtraText string
 	markdownFlavor        backend.MarkdownFlavor
 }
@@ -79,6 +84,15 @@ func (m *mockBackend) SystemPromptExtra() string {
 
 func (m *mockBackend) MarkdownFlavor() backend.MarkdownFlavor {
 	return m.markdownFlavor
+}
+
+// BroadcastModels satisfies modelsBroadcaster. It records the ctx so
+// tests can assert the call happened and was passed a real context.
+func (m *mockBackend) BroadcastModels(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.broadcastCtxs = append(m.broadcastCtxs, ctx)
 }
 
 // newTestApp creates a mockBackend + App wired together for testing.
@@ -285,4 +299,228 @@ func TestFormatToolCall(t *testing.T) {
 	check(bash, backend.MarkdownNone, "🔧 ls -la")
 	check(read, backend.MarkdownBasic, "📄 reading `/etc/hosts`")
 	check(read, backend.MarkdownNone, "📄 reading /etc/hosts")
+}
+
+// newFakePiApp wires App + a fake-pi-backed Worker on a shared in-memory
+// DB and starts worker.Run in a goroutine. Handlers that go through the
+// inbox (ListModels, SetModel, prompt) all dispatch against the same
+// store. Cleanup cancels Run and stops pi.
+func newFakePiApp(t *testing.T) (*App, *mockBackend) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	db := newTestDB(ctx, t)
+	inbox := newTestInboxWithDB(ctx, t, db)
+
+	script, err := filepath.Abs("testdata/fake-pi")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+
+	worker := NewWorker(inbox, PiConfig{
+		BinaryPath: "bash",
+		BinaryArgs: []string{script},
+		SessionDir: dir,
+		WorkingDir: dir,
+	}, "", "")
+	t.Cleanup(worker.stopPi)
+
+	mb := &mockBackend{}
+	worker.SetBackend(mb)
+	worker.SetRoomID(testRoom)
+
+	app := NewApp(mb, worker, inbox, db)
+	worker.SetApp(app)
+
+	go worker.Run(ctx)
+
+	return app, mb
+}
+
+// TestApp_ModelsCommand exercises the !models chat command end-to-end
+// against the fake-pi stub: the worker cold-spawns pi, ListModels merges
+// get_state into get_available_models, and the App formats the result
+// as a single text reply. This is the path matrix/signal/nostr clients
+// take — they have no structured 'models' event, only chat text.
+func TestApp_ModelsCommand(t *testing.T) {
+	t.Parallel()
+
+	app, mb := newFakePiApp(t)
+	sendCommand(app, "!models")
+
+	msg := waitForReply(t, mb)
+
+	for _, want := range []string{"local/qwen3", "local/gpt-oss", "* local/qwen3"} {
+		if !strings.Contains(msg.text, want) {
+			t.Errorf("reply %q missing %q", msg.text, want)
+		}
+	}
+}
+
+// TestApp_ModelCommand covers !model dispatch: argument parsing, the
+// success path (response echoes the new active model), and the two
+// usage-error paths that short-circuit before touching the worker.
+func TestApp_ModelCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		command      string
+		wantContains string
+		// hitsWorker is true when the case is expected to round-trip
+		// through pi (success path). False cases reject in-process.
+		hitsWorker bool
+	}{
+		{"no arg", "!model", "Usage: !model", false},
+		{"missing slash", "!model qwen3", "Invalid model spec", false},
+		{"empty provider", "!model /qwen3", "Invalid model spec", false},
+		{"empty id", "!model local/", "Invalid model spec", false},
+		{"success", "!model local/gpt-oss", "Model switched to local/gpt-oss", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app, mb := newFakePiApp(t)
+			sendCommand(app, tc.command)
+
+			msg := waitForReply(t, mb)
+
+			if !strings.Contains(msg.text, tc.wantContains) {
+				t.Errorf("reply %q missing %q", msg.text, tc.wantContains)
+			}
+
+			_ = tc.hitsWorker // documents intent; no further assert needed.
+		})
+	}
+}
+
+// waitForReply blocks until mockBackend has received at least one
+// SendMessage and returns it. Model commands go through the inbox so
+// the reply lands asynchronously after worker.Run dispatches.
+func waitForReply(t *testing.T, mb *mockBackend) sentMessage {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mb.mu.Lock()
+		n := len(mb.sentMessages)
+		mb.mu.Unlock()
+
+		if n > 0 {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	if len(mb.sentMessages) == 0 {
+		t.Fatal("no reply received within deadline")
+	}
+
+	return mb.sentMessages[0]
+}
+
+// waitForBroadcastCount blocks until mockBackend has recorded `want`
+// BroadcastModels calls or a deadline expires. Used to synchronize
+// against the worker's async post-spawn broadcast goroutine.
+func waitForBroadcastCount(t *testing.T, mb *mockBackend, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mb.mu.Lock()
+		n := len(mb.broadcastCtxs)
+		mb.mu.Unlock()
+
+		if n >= want {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	t.Fatalf("BroadcastModels count = %d, want >= %d", len(mb.broadcastCtxs), want)
+}
+
+// TestApp_ModelCommand_BroadcastsOnSuccess covers the multi-client GUI
+// case: after a successful !model switch, the App pushes a fresh model
+// list to other connected clients so dropdowns reconcile without a
+// manual reopen. The mockBackend satisfies modelsBroadcaster; matrix /
+// signal / nostr don't, and for them the call is silently skipped (a
+// separate test isn't necessary because not implementing the interface
+// is the absence of behavior).
+func TestApp_ModelCommand_BroadcastsOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	app, mb := newFakePiApp(t)
+
+	// Warm pi up first. The worker's ensurePi hook fires an async
+	// broadcast on cold-spawn (existing behaviour from the socket feature
+	// commit). Wait for that to land before snapshotting, so the count we
+	// observe after !model isolates the broadcast handleModel itself
+	// triggers.
+	sendCommand(app, "!models")
+
+	_ = waitForReply(t, mb)
+
+	waitForBroadcastCount(t, mb, 1)
+
+	mb.mu.Lock()
+	before := len(mb.broadcastCtxs)
+	mb.sentMessages = nil
+	mb.mu.Unlock()
+
+	sendCommand(app, "!model local/qwen3")
+
+	// The confirmation reply is sent after BroadcastModels, so observing
+	// the reply means handleModel's broadcast already happened. Pi is
+	// already alive at this point so ensurePi does NOT fire its own
+	// spawn broadcast — anything past `before` came from handleModel.
+	_ = waitForReply(t, mb)
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	gained := len(mb.broadcastCtxs) - before
+	if gained != 1 {
+		t.Fatalf("handleModel triggered %d BroadcastModels calls, want 1 (before=%d, after=%d)",
+			gained, before, len(mb.broadcastCtxs))
+	}
+
+	if mb.broadcastCtxs[len(mb.broadcastCtxs)-1] == nil {
+		t.Fatal("BroadcastModels received a nil context")
+	}
+}
+
+// TestApp_ModelCommand_NoBroadcastOnFailure asserts the broadcast is
+// skipped when set-model fails (bad provider/id, pi rejects, etc.) —
+// pushing stale state to all clients on a failed switch would be worse
+// than the original problem.
+func TestApp_ModelCommand_NoBroadcastOnFailure(t *testing.T) {
+	t.Parallel()
+
+	app, mb := newFakePiApp(t)
+	// Invalid spec rejects in-process before worker.SetModel is called.
+	sendCommand(app, "!model qwen3")
+
+	_ = waitForReply(t, mb)
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	if len(mb.broadcastCtxs) != 0 {
+		t.Fatalf("BroadcastModels called %d times on failure, want 0", len(mb.broadcastCtxs))
+	}
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -72,3 +72,17 @@ type Streamer interface {
 
 // MessageHandler is a callback invoked by the backend for each inbound user message.
 type MessageHandler func(ctx context.Context, msg Message)
+
+// ModelInfo describes a model available in the agent's model registry.
+//
+//nolint:tagliatelle // match pi protocol camelCase
+type ModelInfo struct {
+	Provider      string `json:"provider"`
+	ID            string `json:"id"`
+	ContextWindow int    `json:"contextWindow"`
+	Reasoning     bool   `json:"reasoning"`
+	// Active is true when this model is currently selected in the agent
+	// session. Populated by the worker by merging get_state into the
+	// get_available_models list; pi itself does not set this flag.
+	Active bool `json:"active"`
+}

--- a/inbox_test.go
+++ b/inbox_test.go
@@ -27,6 +27,14 @@ func newTestDBAt(ctx context.Context, t *testing.T, path string) *sql.DB {
 		t.Fatal(err)
 	}
 
+	// modernc/sqlite gives each pool connection its own private
+	// `:memory:` DB unless cache=shared is set in the DSN. Without
+	// that, only the connection that ran the schema migration knows
+	// the tables exist; any query the pool routes to a second
+	// connection fails with "no such table". Pin the pool to one
+	// connection so test DBs behave like a single shared instance.
+	db.SetMaxOpenConns(1)
+
 	if _, err := db.ExecContext(ctx, dbSchema); err != nil {
 		db.Close()
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func wireServices(ctx context.Context, cfg *Config, db *sql.DB, inbox *InboxStor
 
 	var app *App
 
-	b, err := createBackend(ctx, cfg,
+	b, err := createBackend(ctx, cfg, worker,
 		func(ctx context.Context, msg backend.Message) { app.HandleMessage(ctx, msg) },
 		func(_ string) { worker.Restart() },
 	)
@@ -221,7 +221,7 @@ func wireServices(ctx context.Context, cfg *Config, db *sql.DB, inbox *InboxStor
 	return b, worker, nil
 }
 
-func createBackend(ctx context.Context, cfg *Config, handler backend.MessageHandler, onRoomCleanup func(string)) (backend.Backend, error) { //nolint:ireturn // factory returns interface by design
+func createBackend(ctx context.Context, cfg *Config, worker *Worker, handler backend.MessageHandler, onRoomCleanup func(string)) (backend.Backend, error) { //nolint:ireturn // factory returns interface by design
 	switch cfg.BackendType {
 	case backendMatrix:
 		return createMatrixBackend(cfg, handler, onRoomCleanup)
@@ -230,7 +230,7 @@ func createBackend(ctx context.Context, cfg *Config, handler backend.MessageHand
 	case backendSignal:
 		return createSignalBackend(cfg, handler)
 	case backendSocket:
-		return createSocketBackend(cfg, handler)
+		return createSocketBackend(cfg, handler, worker)
 	default:
 		return nil, fmt.Errorf("unsupported backend type: %q", cfg.BackendType)
 	}
@@ -311,11 +311,11 @@ func createNostrBackend(ctx context.Context, cfg *Config, handler backend.Messag
 	return b, nil
 }
 
-func createSocketBackend(cfg *Config, handler backend.MessageHandler) (*socketbackend.Backend, error) {
+func createSocketBackend(cfg *Config, handler backend.MessageHandler, models socketbackend.ModelService) (*socketbackend.Backend, error) {
 	b, err := socketbackend.New(socketbackend.Config{
 		SocketPath: cfg.Socket.SocketPath,
 		Name:       cfg.Socket.Name,
-	}, handler)
+	}, handler, models)
 	if err != nil {
 		return nil, fmt.Errorf("creating socket backend: %w", err)
 	}

--- a/pi_models_test.go
+++ b/pi_models_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPiProcess_ListModels verifies that ListModels parses pi's
+// get_available_models response into a ModelInfo slice and merges the
+// Active flag from get_state.
+func TestPiProcess_ListModels(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	// Spawn pi via sendWithRetry so the process is live.
+	if _, _, err := w.sendWithRetry(t.Context(), "hello", nil); err != nil {
+		t.Fatalf("sendWithRetry: %v", err)
+	}
+
+	pi := w.pi
+	if pi == nil || !pi.IsAlive() {
+		t.Fatal("pi not alive after initial prompt")
+	}
+
+	models, err := pi.ListModels(t.Context())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+
+	want := []ModelInfo{
+		{Provider: "local", ID: "qwen3", ContextWindow: 32768, Reasoning: false, Active: true},
+		{Provider: "local", ID: "gpt-oss", ContextWindow: 131072, Reasoning: true},
+	}
+
+	if !reflect.DeepEqual(models, want) {
+		t.Fatalf("ListModels = %+v, want %+v", models, want)
+	}
+}
+
+// TestPiProcess_SetModel verifies that SetModel sends the right command
+// shape (provider + modelId) and parses the response.
+func TestPiProcess_SetModel(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	if _, _, err := w.sendWithRetry(t.Context(), "hello", nil); err != nil {
+		t.Fatalf("sendWithRetry: %v", err)
+	}
+
+	pi := w.pi
+	if pi == nil || !pi.IsAlive() {
+		t.Fatal("pi not alive after initial prompt")
+	}
+
+	model, err := pi.SetModel(t.Context(), "local", "gpt-oss")
+	if err != nil {
+		t.Fatalf("SetModel: %v", err)
+	}
+
+	if model == nil {
+		t.Fatal("SetModel returned nil model")
+	}
+
+	if model.Provider != "local" || model.ID != "gpt-oss" {
+		t.Fatalf("SetModel = %+v, want provider=local id=gpt-oss", *model)
+	}
+}
+
+// TestPiProcess_ListModels_DeadProcess verifies that ListModels fails
+// fast with a meaningful error when pi is not alive.
+func TestPiProcess_ListModels_DeadProcess(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	// Spawn then kill so we have a non-nil but dead PiProcess.
+	if _, _, err := w.sendWithRetry(t.Context(), "hello", nil); err != nil {
+		t.Fatalf("sendWithRetry: %v", err)
+	}
+
+	pi := w.pi
+	pi.Kill()
+
+	if _, err := pi.ListModels(t.Context()); err == nil {
+		t.Fatal("ListModels on dead process should return error")
+	}
+}
+
+// TestPiProcess_SetModel_DeadProcess verifies SetModel fails fast on dead pi.
+func TestPiProcess_SetModel_DeadProcess(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	if _, _, err := w.sendWithRetry(t.Context(), "hello", nil); err != nil {
+		t.Fatalf("sendWithRetry: %v", err)
+	}
+
+	pi := w.pi
+	pi.Kill()
+
+	if _, err := pi.SetModel(t.Context(), "local", "qwen3"); err == nil {
+		t.Fatal("SetModel on dead process should return error")
+	}
+}

--- a/pi_rpc.go
+++ b/pi_rpc.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/pinpox/opencrow/backend"
 )
 
 // rpcParsed is sent from the persistent stdout reader to the caller.
@@ -440,33 +442,36 @@ func (p *PiProcess) waitForResult(ctx context.Context, onDelta func(string)) (st
 	return w.reply, nil
 }
 
-func (p *PiProcess) waitForCompactResponse(ctx context.Context) (*CompactResult, error) {
-	var result *CompactResult
-
+// waitForResponse drains events until a response for the given command
+// arrives, unmarshals its data into dst, and returns. Context cancellation
+// is wrapped with a uniform error message. Failed responses are caught
+// by handleSideEffects before reaching the callback.
+func (p *PiProcess) waitForResponse(ctx context.Context, command string, dst any) error {
 	err := p.drainEvents(ctx, func(evt rpcEvent) (bool, error) {
-		if evt.Type != rpcTypeResponse || evt.Command != "compact" {
+		if evt.Type != rpcTypeResponse || evt.Command != command {
 			return false, nil
 		}
 
-		// Failed responses are already caught by handleSideEffects.
-		var cr CompactResult
-		if err := json.Unmarshal(evt.Data, &cr); err != nil {
-			return false, fmt.Errorf("parsing compact result: %w", err)
+		if err := json.Unmarshal(evt.Data, dst); err != nil {
+			return false, fmt.Errorf("parsing %s result: %w", command, err)
 		}
-
-		result = &cr
 
 		return true, nil
 	})
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("context cancelled: %w", ctx.Err())
-		}
+	if err != nil && ctx.Err() != nil {
+		return fmt.Errorf("context cancelled: %w", ctx.Err())
+	}
 
+	return err
+}
+
+func (p *PiProcess) waitForCompactResponse(ctx context.Context) (*CompactResult, error) {
+	var cr CompactResult
+	if err := p.waitForResponse(ctx, "compact", &cr); err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return &cr, nil
 }
 
 func (p *PiProcess) autoRespondExtensionUI(evt rpcEvent) {
@@ -543,4 +548,99 @@ func parseAssistantContent(raw json.RawMessage) string {
 	}
 
 	return strings.Join(parts, "\n")
+}
+
+// ModelInfo is re-exported from the backend package for convenience.
+type ModelInfo = backend.ModelInfo
+
+// ListModels asks pi for the list of configured models. The currently
+// active model is marked with Active=true by also fetching get_state
+// — pi's get_available_models response on its own carries no active
+// indicator, and clients need it to render the "selected" state.
+func (p *PiProcess) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	if !p.IsAlive() {
+		return nil, errors.New("pi process is not alive")
+	}
+
+	if err := p.sendCommand(map[string]string{"type": "get_available_models"}); err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Models []ModelInfo `json:"models"`
+	}
+	if err := p.waitForResponse(ctx, "get_available_models", &resp); err != nil {
+		return nil, err
+	}
+
+	models := resp.Models
+
+	active, err := p.getActiveModel(ctx)
+	if err != nil {
+		// State lookup failed — return the list anyway so the UI can
+		// still populate the dropdown. The user just won't see which
+		// model is selected until the next set_model.
+		slog.Warn("pi: get_state failed; active model unknown", "error", err)
+
+		return models, nil
+	}
+
+	if active.Provider == "" || active.ID == "" {
+		// No model in session yet (e.g. fresh start before first prompt).
+		return models, nil
+	}
+
+	for i := range models {
+		if models[i].Provider == active.Provider && models[i].ID == active.ID {
+			models[i].Active = true
+
+			break
+		}
+	}
+
+	return models, nil
+}
+
+// getActiveModel returns the currently selected model from pi's session
+// state, or an empty ModelInfo if none is set. Used by ListModels to
+// stamp the Active flag on the matching list entry.
+func (p *PiProcess) getActiveModel(ctx context.Context) (ModelInfo, error) {
+	if err := p.sendCommand(map[string]string{"type": "get_state"}); err != nil {
+		return ModelInfo{}, err
+	}
+
+	var state struct {
+		Model *ModelInfo `json:"model"`
+	}
+	if err := p.waitForResponse(ctx, "get_state", &state); err != nil {
+		return ModelInfo{}, err
+	}
+
+	if state.Model == nil {
+		return ModelInfo{}, nil
+	}
+
+	return *state.Model, nil
+}
+
+// SetModel tells pi to switch to a different model.
+func (p *PiProcess) SetModel(ctx context.Context, provider, modelID string) (*ModelInfo, error) {
+	if !p.IsAlive() {
+		return nil, errors.New("pi process is not alive")
+	}
+
+	if err := p.sendCommand(map[string]any{
+		"type":     "set_model",
+		"provider": provider,
+		"modelId":  modelID,
+	}); err != nil {
+		return nil, err
+	}
+
+	var m ModelInfo
+	if err := p.waitForResponse(ctx, "set_model", &m); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
 }

--- a/socket/backend.go
+++ b/socket/backend.go
@@ -483,24 +483,20 @@ func (b *Backend) handleListModels(ctx context.Context, conn net.Conn) {
 }
 
 // handleSetModel forwards a set-model command to the model service.
-// On success the new active model is broadcast to every connected
-// client as a 'models' event with Active=true. On failure the
-// requesting client receives an error event. Validation (including
-// empty args) is left to pi: either the model exists and switches, or
-// it doesn't and pi reports why.
+// On success the worker has switched pi to the requested model and we
+// broadcast a fresh full list to every connected client so all dropdowns
+// reconcile their active marker — a partial single-entry push would leave
+// clients that connected late (or before list-models replied) with a
+// one-entry view. On failure the requesting client receives an error
+// event. Validation (including empty args) is left to pi: either the
+// model exists and switches, or it doesn't and pi reports why.
 func (b *Backend) handleSetModel(ctx context.Context, cmd command, conn net.Conn) {
-	model, err := b.models.SetModel(ctx, cmd.Provider, cmd.ModelID)
-	if err != nil {
+	if _, err := b.models.SetModel(ctx, cmd.Provider, cmd.ModelID); err != nil {
 		slog.Warn("socket: set model failed", "error", err, "provider", cmd.Provider, "modelId", cmd.ModelID)
 		b.pushTo(conn, event{Kind: evError, Text: "set-model failed: " + err.Error()})
 
 		return
 	}
 
-	// Broadcast the updated active model to all clients. Other clients
-	// match it against their cached list by (provider, id); the absence
-	// of the rest of the list here is intentional.
-	active := *model
-	active.Active = true
-	b.push(event{Kind: evModels, Models: []backend.ModelInfo{active}})
+	b.BroadcastModels(ctx)
 }

--- a/socket/backend.go
+++ b/socket/backend.go
@@ -42,6 +42,7 @@ const (
 	evAck    eventKind = "ack"
 	evImg    eventKind = "img"
 	evError  eventKind = "error"
+	evModels eventKind = "models"
 )
 
 type dir string
@@ -61,18 +62,19 @@ const (
 //
 //nolint:tagliatelle // protocol compatibility with nostr-chatd
 type event struct {
-	Kind        eventKind `json:"kind"`
-	Msg         *message  `json:"msg,omitempty"`
-	Target      string    `json:"target,omitempty"`
-	Mark        string    `json:"mark,omitempty"`
-	Image       string    `json:"image,omitempty"`
-	State       msgState  `json:"state,omitempty"`
-	Streaming   bool      `json:"streaming"`
-	RelaysUp    int       `json:"relaysUp"`
-	RelaysTotal int       `json:"relaysTotal,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Unread      int       `json:"unread,omitempty"`
-	Text        string    `json:"text,omitempty"`
+	Kind        eventKind           `json:"kind"`
+	Msg         *message            `json:"msg,omitempty"`
+	Target      string              `json:"target,omitempty"`
+	Mark        string              `json:"mark,omitempty"`
+	Image       string              `json:"image,omitempty"`
+	State       msgState            `json:"state,omitempty"`
+	Streaming   bool                `json:"streaming"`
+	RelaysUp    int                 `json:"relaysUp"`
+	RelaysTotal int                 `json:"relaysTotal,omitempty"`
+	Name        string              `json:"name,omitempty"`
+	Unread      int                 `json:"unread,omitempty"`
+	Text        string              `json:"text,omitempty"`
+	Models      []backend.ModelInfo `json:"models,omitempty"`
 }
 
 //nolint:tagliatelle // protocol compatibility with nostr-chatd
@@ -93,30 +95,42 @@ type message struct {
 type cmdName string
 
 const (
-	cmdSend     cmdName = "send"
-	cmdSendFile cmdName = "send-file"
-	cmdReplay   cmdName = "replay"
-	cmdMarkRead cmdName = "mark-read"
+	cmdSend       cmdName = "send"
+	cmdSendFile   cmdName = "send-file"
+	cmdReplay     cmdName = "replay"
+	cmdMarkRead   cmdName = "mark-read"
+	cmdListModels cmdName = "list-models"
+	cmdSetModel   cmdName = "set-model"
 )
 
 //nolint:tagliatelle // protocol compatibility with nostr-chatd
 type command struct {
-	Cmd     cmdName `json:"cmd"`
-	Text    string  `json:"text,omitempty"`
-	ReplyTo string  `json:"replyTo,omitempty"`
-	Path    string  `json:"path,omitempty"`
-	N       int     `json:"n,omitempty"`
-	Type    string  `json:"type,omitempty"`
+	Cmd      cmdName `json:"cmd"`
+	Text     string  `json:"text,omitempty"`
+	ReplyTo  string  `json:"replyTo,omitempty"`
+	Path     string  `json:"path,omitempty"`
+	N        int     `json:"n,omitempty"`
+	Type     string  `json:"type,omitempty"`
+	Provider string  `json:"provider,omitempty"`
+	ModelID  string  `json:"modelId,omitempty"` //nolint:tagliatelle // match pi protocol camelCase
 }
 
 // --- Backend implementation ---
 
 const conversationID = "local"
 
+// ModelService exposes model listing and switching. Implemented by the
+// Worker; injected so the socket package stays transport-only.
+type ModelService interface {
+	ListModels(ctx context.Context) ([]backend.ModelInfo, error)
+	SetModel(ctx context.Context, provider, modelID string) (*backend.ModelInfo, error)
+}
+
 // Backend implements backend.Backend over a local UNIX socket.
 type Backend struct {
 	cfg     Config
 	handler backend.MessageHandler
+	models  ModelService
 
 	cancel backend.Canceler
 
@@ -126,10 +140,15 @@ type Backend struct {
 	msgSeq atomic.Int64
 }
 
-// New creates a new socket backend.
-func New(cfg Config, handler backend.MessageHandler) (*Backend, error) {
+// New creates a new socket backend. models is required; pass a no-op
+// implementation if the backend should never serve model commands.
+func New(cfg Config, handler backend.MessageHandler, models ModelService) (*Backend, error) {
 	if cfg.SocketPath == "" {
 		return nil, errors.New("socket path is required")
+	}
+
+	if models == nil {
+		return nil, errors.New("model service is required")
 	}
 
 	if cfg.Name == "" {
@@ -139,6 +158,7 @@ func New(cfg Config, handler backend.MessageHandler) (*Backend, error) {
 	return &Backend{
 		cfg:     cfg,
 		handler: handler,
+		models:  models,
 		conns:   make(map[net.Conn]struct{}),
 	}, nil
 }
@@ -276,6 +296,22 @@ func (b *Backend) MarkdownFlavor() backend.MarkdownFlavor {
 	return backend.MarkdownFull
 }
 
+// BroadcastModels fetches the current model list via the injected
+// service and pushes it to every connected client. Called by the
+// worker after a fresh pi spawn so dropdowns sync without any
+// client-side polling. Safe to call concurrently with prompt
+// processing — the underlying ListModels serializes on the worker.
+func (b *Backend) BroadcastModels(ctx context.Context) {
+	models, err := b.models.ListModels(ctx)
+	if err != nil {
+		slog.Warn("socket: broadcast models failed", "error", err)
+
+		return
+	}
+
+	b.push(event{Kind: evModels, Models: models})
+}
+
 // --- Internal ---
 
 func (b *Backend) handleConn(ctx context.Context, conn net.Conn) {
@@ -311,6 +347,9 @@ func (b *Backend) handleCommand(ctx context.Context, cmd command, conn net.Conn)
 	case cmdSendFile:
 		b.handleSendFile(ctx, cmd)
 	case cmdReplay:
+		// Always emits exactly one status event back to the caller.
+		// Tests (dialSynced) and clients rely on this to confirm the
+		// connection is registered before subsequent broadcasts.
 		b.pushTo(conn, event{
 			Kind:        evStatus,
 			Streaming:   true,
@@ -320,6 +359,10 @@ func (b *Backend) handleCommand(ctx context.Context, cmd command, conn net.Conn)
 		})
 	case cmdMarkRead:
 		// No-op for local backend.
+	case cmdListModels:
+		b.handleListModels(ctx, conn)
+	case cmdSetModel:
+		b.handleSetModel(ctx, cmd, conn)
 	default:
 		slog.Warn("socket: unknown command", "cmd", cmd.Cmd)
 	}
@@ -420,4 +463,44 @@ func (b *Backend) pushTo(conn net.Conn, ev event) {
 
 func (b *Backend) nextID() string {
 	return "local-" + strconv.FormatInt(b.msgSeq.Add(1), 10)
+}
+
+// handleListModels responds with the model list as a 'models' event.
+// On failure the requesting client receives an error event carrying
+// the underlying message — the worker cold-spawns pi as part of
+// list-models, so reaching this error path means something is
+// genuinely broken and the UI should surface it.
+func (b *Backend) handleListModels(ctx context.Context, conn net.Conn) {
+	models, err := b.models.ListModels(ctx)
+	if err != nil {
+		slog.Warn("socket: list models failed", "error", err)
+		b.pushTo(conn, event{Kind: evError, Text: "list-models failed: " + err.Error()})
+
+		return
+	}
+
+	b.pushTo(conn, event{Kind: evModels, Models: models})
+}
+
+// handleSetModel forwards a set-model command to the model service.
+// On success the new active model is broadcast to every connected
+// client as a 'models' event with Active=true. On failure the
+// requesting client receives an error event. Validation (including
+// empty args) is left to pi: either the model exists and switches, or
+// it doesn't and pi reports why.
+func (b *Backend) handleSetModel(ctx context.Context, cmd command, conn net.Conn) {
+	model, err := b.models.SetModel(ctx, cmd.Provider, cmd.ModelID)
+	if err != nil {
+		slog.Warn("socket: set model failed", "error", err, "provider", cmd.Provider, "modelId", cmd.ModelID)
+		b.pushTo(conn, event{Kind: evError, Text: "set-model failed: " + err.Error()})
+
+		return
+	}
+
+	// Broadcast the updated active model to all clients. Other clients
+	// match it against their cached list by (provider, id); the absence
+	// of the rest of the list here is intentional.
+	active := *model
+	active.Active = true
+	b.push(event{Kind: evModels, Models: []backend.ModelInfo{active}})
 }

--- a/socket/backend_test.go
+++ b/socket/backend_test.go
@@ -16,16 +16,25 @@ import (
 func TestNew_RequiresSocketPath(t *testing.T) {
 	t.Parallel()
 
-	_, err := New(Config{}, func(_ context.Context, _ backend.Message) {})
+	_, err := New(Config{}, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	if err == nil {
 		t.Fatal("expected error for empty SocketPath")
+	}
+}
+
+func TestNew_RequiresModelService(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(Config{SocketPath: "/tmp/test.sock"}, func(_ context.Context, _ backend.Message) {}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil model service")
 	}
 }
 
 func TestNew_DefaultName(t *testing.T) {
 	t.Parallel()
 
-	b, err := New(Config{SocketPath: "/tmp/test.sock"}, func(_ context.Context, _ backend.Message) {})
+	b, err := New(Config{SocketPath: "/tmp/test.sock"}, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -37,12 +46,13 @@ func TestNew_DefaultName(t *testing.T) {
 
 // startBackend starts a socket backend in a goroutine, returning the
 // backend and a cleanup function. The socket is created in t.TempDir().
-func startBackend(t *testing.T, handler backend.MessageHandler) (*Backend, string, context.CancelFunc) {
+// Tests that don't exercise model commands can pass a zero stubModelService.
+func startBackend(t *testing.T, handler backend.MessageHandler, models ModelService) (*Backend, string, context.CancelFunc) {
 	t.Helper()
 
 	sockPath := filepath.Join(t.TempDir(), "test.sock")
 
-	b, err := New(Config{SocketPath: sockPath, Name: "TestBot"}, handler)
+	b, err := New(Config{SocketPath: sockPath, Name: "TestBot"}, handler, models)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -78,6 +88,32 @@ func dial(t *testing.T, sockPath string) net.Conn {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
+
+	return conn
+}
+
+// dialSynced dials and round-trips a replay command, ensuring the
+// server has fully registered the connection in b.conns before
+// returning. Use this when the test relies on broadcast push() reaching
+// the connection — without sync, Accept()→register can lose events to
+// the dial-then-broadcast race under parallel load.
+func dialSynced(t *testing.T, sockPath string) net.Conn {
+	t.Helper()
+
+	conn := dial(t, sockPath)
+
+	if _, err := conn.Write([]byte(`{"cmd":"replay"}` + "\n")); err != nil {
+		t.Fatalf("dialSynced: write replay: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	var buf [1024]byte
+	if _, err := conn.Read(buf[:]); err != nil {
+		t.Fatalf("dialSynced: drain replay response: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Time{})
 
 	return conn
 }
@@ -134,7 +170,7 @@ func sendCommand(t *testing.T, conn net.Conn, cmd command) {
 func TestReplay_ReturnsStatus(t *testing.T) {
 	t.Parallel()
 
-	_, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	_, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	defer cancel()
 
 	conn := dial(t, sockPath)
@@ -172,7 +208,7 @@ func TestSend_DeliversToHandler(t *testing.T) {
 		mu.Unlock()
 	}
 
-	_, sockPath, cancel := startBackend(t, handler)
+	_, sockPath, cancel := startBackend(t, handler, &stubModelService{})
 	defer cancel()
 
 	conn := dial(t, sockPath)
@@ -222,7 +258,7 @@ func TestSend_EmptyTextIgnored(t *testing.T) {
 		called = true
 	}
 
-	_, sockPath, cancel := startBackend(t, handler)
+	_, sockPath, cancel := startBackend(t, handler, &stubModelService{})
 	defer cancel()
 
 	conn := dial(t, sockPath)
@@ -239,10 +275,10 @@ func TestSend_EmptyTextIgnored(t *testing.T) {
 func TestSendMessage_PushesToClients(t *testing.T) {
 	t.Parallel()
 
-	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	defer cancel()
 
-	conn := dial(t, sockPath)
+	conn := dialSynced(t, sockPath)
 	defer conn.Close()
 
 	// SendMessage from the backend side (simulating a bot reply).
@@ -269,10 +305,10 @@ func TestSendMessage_PushesToClients(t *testing.T) {
 func TestSendFile_PushesImageEvent(t *testing.T) {
 	t.Parallel()
 
-	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	defer cancel()
 
-	conn := dial(t, sockPath)
+	conn := dialSynced(t, sockPath)
 	defer conn.Close()
 
 	err := b.SendFile(context.Background(), "local", "/tmp/chart.png")
@@ -306,7 +342,7 @@ func TestSendFile_Command(t *testing.T) {
 		mu.Unlock()
 	}
 
-	_, sockPath, cancel := startBackend(t, handler)
+	_, sockPath, cancel := startBackend(t, handler, &stubModelService{})
 	defer cancel()
 
 	conn := dial(t, sockPath)
@@ -337,10 +373,10 @@ func TestSendFile_Command(t *testing.T) {
 func TestSendDelta_StreamsToClients(t *testing.T) {
 	t.Parallel()
 
-	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	b, sockPath, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	defer cancel()
 
-	conn := dial(t, sockPath)
+	conn := dialSynced(t, sockPath)
 	defer conn.Close()
 
 	cs := newConnScanner(conn)
@@ -371,7 +407,7 @@ func TestSendDelta_StreamsToClients(t *testing.T) {
 func TestBackend_ImplementsStreamer(t *testing.T) {
 	t.Parallel()
 
-	b, _, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {})
+	b, _, cancel := startBackend(t, func(_ context.Context, _ backend.Message) {}, &stubModelService{})
 	defer cancel()
 
 	// Verify the socket backend implements backend.Streamer.

--- a/socket/models_test.go
+++ b/socket/models_test.go
@@ -12,16 +12,19 @@ import (
 
 // Test fixtures used across model tests.
 const (
-	testProvider = "local"
-	testModelID  = "qwen3"
+	testProvider   = "local"
+	testModelID    = "qwen3"
+	testAltModelID = "gpt-oss"
 )
 
 // stubModelService is a test double for the ModelService interface.
+// SetModel is stateful: it updates the Active flag in `models` so a
+// subsequent ListModels (e.g. from BroadcastModels after a successful
+// switch) returns a list whose active marker matches what was just set.
 type stubModelService struct {
 	models     []backend.ModelInfo
 	listErr    error
 	setErr     error
-	lastSet    *backend.ModelInfo
 	setCallArg struct {
 		provider string
 		modelID  string
@@ -44,11 +47,22 @@ func (s *stubModelService) SetModel(_ context.Context, provider, modelID string)
 		return nil, s.setErr
 	}
 
-	if s.lastSet != nil {
-		return s.lastSet, nil
+	var active *backend.ModelInfo
+
+	for i := range s.models {
+		match := s.models[i].Provider == provider && s.models[i].ID == modelID
+		s.models[i].Active = match
+
+		if match {
+			active = &s.models[i]
+		}
 	}
 
-	return &backend.ModelInfo{Provider: provider, ID: modelID, ContextWindow: 4096}, nil
+	if active != nil {
+		return active, nil
+	}
+
+	return &backend.ModelInfo{Provider: provider, ID: modelID, ContextWindow: 4096, Active: true}, nil
 }
 
 func TestListModels_ReturnsModels(t *testing.T) {
@@ -57,7 +71,7 @@ func TestListModels_ReturnsModels(t *testing.T) {
 	svc := &stubModelService{
 		models: []backend.ModelInfo{
 			{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Reasoning: false, Active: true},
-			{Provider: testProvider, ID: "gpt-oss", ContextWindow: 131072, Reasoning: true},
+			{Provider: testProvider, ID: testAltModelID, ContextWindow: 131072, Reasoning: true},
 		},
 	}
 
@@ -76,7 +90,7 @@ func TestListModels_ReturnsModels(t *testing.T) {
 
 	want := []backend.ModelInfo{
 		{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Reasoning: false, Active: true},
-		{Provider: testProvider, ID: "gpt-oss", ContextWindow: 131072, Reasoning: true},
+		{Provider: testProvider, ID: testAltModelID, ContextWindow: 131072, Reasoning: true},
 	}
 
 	if !reflect.DeepEqual(ev.Models, want) {
@@ -110,10 +124,22 @@ func TestListModels_ServiceErrorEmitsError(t *testing.T) {
 	}
 }
 
+// TestSetModel_ForwardsToService asserts the success path: the service
+// is called with the requested provider+id, and the resulting broadcast
+// carries the full model list with Active=true only on the matching
+// entry. A single-entry partial update would leave clients that joined
+// before list-models replied with a one-entry view; we explicitly want
+// the full list so every dropdown can reconcile.
 func TestSetModel_ForwardsToService(t *testing.T) {
 	t.Parallel()
 
-	svc := &stubModelService{}
+	svc := &stubModelService{
+		models: []backend.ModelInfo{
+			{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Active: true},
+			{Provider: testProvider, ID: testAltModelID, ContextWindow: 131072, Reasoning: true},
+			{Provider: testProvider, ID: "smollm", ContextWindow: 4096},
+		},
+	}
 
 	_, sockPath, cancel := startBackend(t, nil, svc)
 	defer cancel()
@@ -121,23 +147,30 @@ func TestSetModel_ForwardsToService(t *testing.T) {
 	conn := dial(t, sockPath)
 	defer conn.Close()
 
-	sendCommand(t, conn, command{Cmd: cmdSetModel, Provider: testProvider, ModelID: testModelID})
+	// Switch to a model that is not currently active so the broadcast
+	// has to flip the marker on two entries.
+	sendCommand(t, conn, command{Cmd: cmdSetModel, Provider: testProvider, ModelID: testAltModelID})
 
 	ev := readEvent(t, conn)
 	if ev.Kind != evModels {
 		t.Fatalf("kind = %q, want %q", ev.Kind, evModels)
 	}
 
-	if len(ev.Models) != 1 || !ev.Models[0].Active {
-		t.Fatalf("expected single active model, got %+v", ev.Models)
+	if len(ev.Models) != len(svc.models) {
+		t.Fatalf("broadcast carried %d models, want full list of %d: %+v",
+			len(ev.Models), len(svc.models), ev.Models)
 	}
 
-	if ev.Models[0].Provider != testProvider || ev.Models[0].ID != testModelID {
-		t.Fatalf("model = %+v, want provider=local id=qwen3", ev.Models[0])
+	for _, m := range ev.Models {
+		wantActive := m.Provider == testProvider && m.ID == testAltModelID
+		if m.Active != wantActive {
+			t.Errorf("model %s/%s: Active=%t, want %t", m.Provider, m.ID, m.Active, wantActive)
+		}
 	}
 
-	if svc.setCallArg.provider != testProvider || svc.setCallArg.modelID != testModelID {
-		t.Fatalf("service called with %+v, want provider=local modelID=qwen3", svc.setCallArg)
+	if svc.setCallArg.provider != testProvider || svc.setCallArg.modelID != testAltModelID {
+		t.Fatalf("service called with %+v, want provider=%s modelID=gpt-oss",
+			svc.setCallArg, testProvider)
 	}
 }
 
@@ -200,6 +233,54 @@ func TestBroadcastModels_PushesToAllClients(t *testing.T) {
 
 		if len(ev.Models) != 2 {
 			t.Fatalf("client %d: expected 2 models, got %+v", i, ev.Models)
+		}
+	}
+}
+
+// TestSetModel_BroadcastsToAllClients covers the multi-client GUI case:
+// one client switches model, every other connected client receives the
+// same full-list event so their dropdowns reconcile without a manual
+// reopen. This is the whole point of going through BroadcastModels
+// instead of pushing a one-entry partial update.
+func TestSetModel_BroadcastsToAllClients(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{
+		models: []backend.ModelInfo{
+			{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Active: true},
+			{Provider: testProvider, ID: testAltModelID, ContextWindow: 131072, Reasoning: true},
+		},
+	}
+
+	_, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	conn1 := dialSynced(t, sockPath)
+	defer conn1.Close()
+
+	conn2 := dialSynced(t, sockPath)
+	defer conn2.Close()
+
+	// Switch from conn1; both conn1 and conn2 must observe the broadcast.
+	sendCommand(t, conn1, command{Cmd: cmdSetModel, Provider: testProvider, ModelID: testAltModelID})
+
+	for i, conn := range []net.Conn{conn1, conn2} {
+		ev := readEvent(t, conn)
+		if ev.Kind != evModels {
+			t.Fatalf("client %d: kind = %q, want %q", i, ev.Kind, evModels)
+		}
+
+		if len(ev.Models) != len(svc.models) {
+			t.Fatalf("client %d: expected full list of %d models, got %+v",
+				i, len(svc.models), ev.Models)
+		}
+
+		for _, m := range ev.Models {
+			wantActive := m.Provider == testProvider && m.ID == testAltModelID
+			if m.Active != wantActive {
+				t.Errorf("client %d: model %s/%s: Active=%t, want %t",
+					i, m.Provider, m.ID, m.Active, wantActive)
+			}
 		}
 	}
 }

--- a/socket/models_test.go
+++ b/socket/models_test.go
@@ -1,0 +1,205 @@
+package socket
+
+import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/pinpox/opencrow/backend"
+)
+
+// Test fixtures used across model tests.
+const (
+	testProvider = "local"
+	testModelID  = "qwen3"
+)
+
+// stubModelService is a test double for the ModelService interface.
+type stubModelService struct {
+	models     []backend.ModelInfo
+	listErr    error
+	setErr     error
+	lastSet    *backend.ModelInfo
+	setCallArg struct {
+		provider string
+		modelID  string
+	}
+}
+
+func (s *stubModelService) ListModels(_ context.Context) ([]backend.ModelInfo, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+
+	return s.models, nil
+}
+
+func (s *stubModelService) SetModel(_ context.Context, provider, modelID string) (*backend.ModelInfo, error) {
+	s.setCallArg.provider = provider
+	s.setCallArg.modelID = modelID
+
+	if s.setErr != nil {
+		return nil, s.setErr
+	}
+
+	if s.lastSet != nil {
+		return s.lastSet, nil
+	}
+
+	return &backend.ModelInfo{Provider: provider, ID: modelID, ContextWindow: 4096}, nil
+}
+
+func TestListModels_ReturnsModels(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{
+		models: []backend.ModelInfo{
+			{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Reasoning: false, Active: true},
+			{Provider: testProvider, ID: "gpt-oss", ContextWindow: 131072, Reasoning: true},
+		},
+	}
+
+	_, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdListModels})
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evModels {
+		t.Fatalf("kind = %q, want %q", ev.Kind, evModels)
+	}
+
+	want := []backend.ModelInfo{
+		{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Reasoning: false, Active: true},
+		{Provider: testProvider, ID: "gpt-oss", ContextWindow: 131072, Reasoning: true},
+	}
+
+	if !reflect.DeepEqual(ev.Models, want) {
+		t.Fatalf("models = %+v, want %+v", ev.Models, want)
+	}
+}
+
+// TestListModels_ServiceErrorEmitsError: when the service rejects the
+// request (pi failed to spawn, RPC error, etc.) the client gets an
+// explicit error event so the UI can surface the failure.
+func TestListModels_ServiceErrorEmitsError(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{listErr: errors.New("pi crash")}
+
+	_, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdListModels})
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evError {
+		t.Fatalf("kind = %q, want %q", ev.Kind, evError)
+	}
+
+	if ev.Text == "" {
+		t.Fatal("error event should carry a non-empty message")
+	}
+}
+
+func TestSetModel_ForwardsToService(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{}
+
+	_, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdSetModel, Provider: testProvider, ModelID: testModelID})
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evModels {
+		t.Fatalf("kind = %q, want %q", ev.Kind, evModels)
+	}
+
+	if len(ev.Models) != 1 || !ev.Models[0].Active {
+		t.Fatalf("expected single active model, got %+v", ev.Models)
+	}
+
+	if ev.Models[0].Provider != testProvider || ev.Models[0].ID != testModelID {
+		t.Fatalf("model = %+v, want provider=local id=qwen3", ev.Models[0])
+	}
+
+	if svc.setCallArg.provider != testProvider || svc.setCallArg.modelID != testModelID {
+		t.Fatalf("service called with %+v, want provider=local modelID=qwen3", svc.setCallArg)
+	}
+}
+
+// TestSetModel_ServiceErrorEmitsError: when the service rejects the
+// requested model (unknown, invalid, pi RPC error) the requesting
+// client gets an error event carrying the underlying message.
+func TestSetModel_ServiceErrorEmitsError(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{setErr: errors.New("model not found")}
+
+	_, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	conn := dial(t, sockPath)
+	defer conn.Close()
+
+	sendCommand(t, conn, command{Cmd: cmdSetModel, Provider: testProvider, ModelID: "nonexistent"})
+
+	ev := readEvent(t, conn)
+	if ev.Kind != evError {
+		t.Fatalf("kind = %q, want %q", ev.Kind, evError)
+	}
+
+	if ev.Text == "" {
+		t.Fatal("error event should carry a non-empty message")
+	}
+}
+
+// TestBroadcastModels_PushesToAllClients: BroadcastModels sends the
+// current list to every connected client, not just one. Used by the
+// worker after a fresh pi spawn so dropdowns sync without polling.
+func TestBroadcastModels_PushesToAllClients(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubModelService{
+		models: []backend.ModelInfo{
+			{Provider: testProvider, ID: testModelID, ContextWindow: 32768, Active: true},
+			{Provider: testProvider, ID: "smollm"},
+		},
+	}
+
+	b, sockPath, cancel := startBackend(t, nil, svc)
+	defer cancel()
+
+	// Two clients, both must observe the broadcast.
+	conn1 := dialSynced(t, sockPath)
+	defer conn1.Close()
+
+	conn2 := dialSynced(t, sockPath)
+	defer conn2.Close()
+
+	b.BroadcastModels(t.Context())
+
+	for i, conn := range []net.Conn{conn1, conn2} {
+		ev := readEvent(t, conn)
+		if ev.Kind != evModels {
+			t.Fatalf("client %d: kind = %q, want %q", i, ev.Kind, evModels)
+		}
+
+		if len(ev.Models) != 2 {
+			t.Fatalf("client %d: expected 2 models, got %+v", i, ev.Models)
+		}
+	}
+}

--- a/testdata/fake-pi
+++ b/testdata/fake-pi
@@ -22,5 +22,21 @@ while IFS= read -r line; do
     *'"type":"compact"'*|*'"type": "compact"'*)
       printf '%s\n' '{"type":"response","command":"compact","success":true,"data":{"tokensBefore":1,"summary":"s"}}'
       ;;
+    *'"type":"get_available_models"'*|*'"type": "get_available_models"'*)
+      printf '%s\n' '{"type":"response","command":"get_available_models","success":true,"data":{"models":[{"provider":"local","id":"qwen3","contextWindow":32768,"reasoning":false},{"provider":"local","id":"gpt-oss","contextWindow":131072,"reasoning":true}]}}'
+      ;;
+    *'"type":"get_state"'*|*'"type": "get_state"'*)
+      # Mirror pi's session state shape. The Active flag in ListModels
+      # comes from cross-referencing this against get_available_models,
+      # so the first model in the list becomes "active" for tests.
+      printf '%s\n' '{"type":"response","command":"get_state","success":true,"data":{"model":{"provider":"local","id":"qwen3","contextWindow":32768,"reasoning":false},"thinkingLevel":"off","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","sessionId":"s","autoCompactionEnabled":false,"messageCount":0,"pendingMessageCount":0}}'
+      ;;
+    *'"type":"set_model"'*|*'"type": "set_model"'*)
+      # Echo back the requested provider/modelId. The test checks routing,
+      # not real registry validation.
+      provider=$(printf '%s' "$line" | sed -n 's/.*"provider":"\([^"]*\)".*/\1/p')
+      modelid=$(printf '%s' "$line" | sed -n 's/.*"modelId":"\([^"]*\)".*/\1/p')
+      printf '%s\n' "{\"type\":\"response\",\"command\":\"set_model\",\"success\":true,\"data\":{\"provider\":\"$provider\",\"id\":\"$modelid\",\"contextWindow\":32768,\"reasoning\":false}}"
+      ;;
   esac
 done

--- a/worker.go
+++ b/worker.go
@@ -19,10 +19,12 @@ import (
 
 // Source names for inbox items.
 const (
-	sourceUser      = "user"
-	sourceTrigger   = "trigger"
-	sourceHeartbeat = "heartbeat"
-	sourceCompact   = "compact"
+	sourceUser       = "user"
+	sourceTrigger    = "trigger"
+	sourceHeartbeat  = "heartbeat"
+	sourceCompact    = "compact"
+	sourceListModels = "list-models"
+	sourceSetModel   = "set-model"
 )
 
 // Worker owns the single pi process and drains the inbox in priority order.
@@ -39,14 +41,17 @@ type Worker struct {
 	hbPrompt      string
 	triggerPrompt string
 
-	// mu protects pi, lastUse, compactResult, currentPriority, currentCancel, freshStart.
-	mu              sync.Mutex
-	pi              *PiProcess
-	freshStart      bool // next ensurePi spawns without --continue
-	lastUse         time.Time
-	currentPriority int64
-	currentCancel   context.CancelFunc
-	compactResult   chan compactOutcome
+	// mu protects pi, lastUse, compactResult, listModelsResult,
+	// setModelResult, currentPriority, currentCancel, freshStart.
+	mu               sync.Mutex
+	pi               *PiProcess
+	freshStart       bool // next ensurePi spawns without --continue
+	lastUse          time.Time
+	currentPriority  int64
+	currentCancel    context.CancelFunc
+	compactResult    chan compactOutcome
+	listModelsResult chan listModelsOutcome
+	setModelResult   chan setModelOutcome
 
 	// wake is signalled (non-blocking) on every Notify call so the
 	// worker can poll the DB for the highest-priority item.
@@ -59,11 +64,31 @@ type compactOutcome struct {
 	err    error
 }
 
+// listModelsOutcome carries the result of a list-models operation.
+type listModelsOutcome struct {
+	models []ModelInfo
+	err    error
+}
+
+// setModelOutcome carries the result of a set-model operation.
+type setModelOutcome struct {
+	model *ModelInfo
+	err   error
+}
+
 // Backend is the subset of backend.Backend the worker needs.
 type Backend interface {
 	SetTyping(ctx context.Context, conversationID string, typing bool)
 	SendMessage(ctx context.Context, conversationID string, text string, replyToID string) string
 	MarkdownFlavor() backend.MarkdownFlavor
+}
+
+// modelsBroadcaster is satisfied by backends that can push the current
+// model list to connected clients. The worker uses it to notify
+// dropdowns when a fresh pi spawns; backends that don't have a model
+// UI (matrix, nostr, signal) simply don't implement it.
+type modelsBroadcaster interface {
+	BroadcastModels(ctx context.Context)
 }
 
 // NewWorker creates a new worker. The pi process is started lazily on first dequeue.
@@ -193,6 +218,71 @@ func (w *Worker) Compact(ctx context.Context) (*CompactResult, error) {
 		return nil, fmt.Errorf("compact cancelled: %w", ctx.Err())
 	case outcome := <-ch:
 		return outcome.result, outcome.err
+	}
+}
+
+// ListModels returns the models available in pi's model registry.
+// Blocks until the worker processes the request.
+func (w *Worker) ListModels(ctx context.Context) ([]ModelInfo, error) {
+	w.mu.Lock()
+	if w.listModelsResult != nil {
+		w.mu.Unlock()
+
+		return nil, errors.New("list-models already in progress")
+	}
+
+	ch := make(chan listModelsOutcome, 1)
+	w.listModelsResult = ch
+	w.mu.Unlock()
+
+	if err := w.inbox.Enqueue(ctx, PriorityUser, sourceListModels, "", ""); err != nil {
+		w.mu.Lock()
+		w.listModelsResult = nil
+		w.mu.Unlock()
+
+		return nil, fmt.Errorf("enqueuing list-models: %w", err)
+	}
+
+	w.Notify(PriorityUser)
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("list-models cancelled: %w", ctx.Err())
+	case outcome := <-ch:
+		return outcome.models, outcome.err
+	}
+}
+
+// SetModel tells pi to switch to a different model.
+// Blocks until the worker processes the request.
+func (w *Worker) SetModel(ctx context.Context, provider, modelID string) (*ModelInfo, error) {
+	w.mu.Lock()
+	if w.setModelResult != nil {
+		w.mu.Unlock()
+
+		return nil, errors.New("set-model already in progress")
+	}
+
+	ch := make(chan setModelOutcome, 1)
+	w.setModelResult = ch
+	w.mu.Unlock()
+
+	// Encode provider/modelID in the inbox row's content/replyTo columns.
+	if err := w.inbox.Enqueue(ctx, PriorityUser, sourceSetModel, provider, modelID); err != nil {
+		w.mu.Lock()
+		w.setModelResult = nil
+		w.mu.Unlock()
+
+		return nil, fmt.Errorf("enqueuing set-model: %w", err)
+	}
+
+	w.Notify(PriorityUser)
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("set-model cancelled: %w", ctx.Err())
+	case outcome := <-ch:
+		return outcome.model, outcome.err
 	}
 }
 
@@ -328,13 +418,22 @@ func (w *Worker) processItem(ctx context.Context, item Inbox) bool {
 		w.mu.Unlock()
 	}()
 
-	if item.Source == sourceCompact {
+	switch item.Source {
+	case sourceCompact:
 		w.processCompact(itemCtx)
 
 		return false
-	}
+	case sourceListModels:
+		w.processListModels(itemCtx)
 
-	return w.processPrompt(itemCtx, item)
+		return false
+	case sourceSetModel:
+		w.processSetModel(itemCtx, item.Content, item.ReplyTo)
+
+		return false
+	default:
+		return w.processPrompt(itemCtx, item)
+	}
 }
 
 // processPrompt handles a user/trigger/heartbeat item. Returns true if
@@ -491,6 +590,56 @@ func (w *Worker) processCompact(ctx context.Context) {
 	ch <- compactOutcome{result: result, err: err}
 }
 
+func (w *Worker) processListModels(ctx context.Context) {
+	w.mu.Lock()
+	ch := w.listModelsResult
+	w.listModelsResult = nil
+	w.mu.Unlock()
+
+	if ch == nil {
+		slog.Warn("worker: list-models item but no result channel")
+
+		return
+	}
+
+	// Cold-spawn pi on first list-models. The GUI typically issues
+	// list-models before any chat traffic to populate its dropdown;
+	// erroring with "no active session" would leave it stuck on
+	// "unknown model" until the user sent a prompt.
+	pi, err := w.ensurePi(ctx)
+	if err != nil {
+		ch <- listModelsOutcome{err: err}
+
+		return
+	}
+
+	models, err := pi.ListModels(ctx)
+	ch <- listModelsOutcome{models: models, err: err}
+}
+
+func (w *Worker) processSetModel(ctx context.Context, provider, modelID string) {
+	w.mu.Lock()
+	ch := w.setModelResult
+	w.setModelResult = nil
+	w.mu.Unlock()
+
+	if ch == nil {
+		slog.Warn("worker: set-model item but no result channel")
+
+		return
+	}
+
+	pi, err := w.ensurePi(ctx)
+	if err != nil {
+		ch <- setModelOutcome{err: err}
+
+		return
+	}
+
+	model, err := pi.SetModel(ctx, provider, modelID)
+	ch <- setModelOutcome{model: model, err: err}
+}
+
 func wasPreempted(ctx context.Context, err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
 		ctx.Err() != nil
@@ -563,6 +712,15 @@ func (w *Worker) ensurePi(ctx context.Context) (*PiProcess, error) {
 	w.mu.Lock()
 	w.pi = pi
 	w.mu.Unlock()
+
+	// Push the current model list to connected clients so dropdowns
+	// populate on the first spawn instead of after the user happens to
+	// close and reopen the panel. Async — BroadcastModels enqueues a
+	// list-models task which the worker picks up after the item that
+	// triggered this ensurePi finishes processing.
+	if mb, ok := w.be.(modelsBroadcaster); ok {
+		go mb.BroadcastModels(context.Background()) //nolint:contextcheck,gosec // post-spawn notification outlives the item ctx
+	}
 
 	return pi, nil
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -161,3 +161,35 @@ func TestWorker_StopPiKillsProcessTree(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 }
+
+// TestWorker_ListModelsColdSpawnsPi covers the dropdown-on-connect case:
+// the GUI issues list-models before any chat traffic. Without cold-spawn
+// behaviour the worker would error with "no active session", leaving the
+// model picker stuck on "unknown" until the user sent a prompt.
+func TestWorker_ListModelsColdSpawnsPi(t *testing.T) {
+	t.Parallel()
+
+	w := newFakePiWorker(t)
+
+	if w.IsActive() {
+		t.Fatal("precondition: worker should be cold")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go w.Run(ctx)
+
+	models, err := w.ListModels(ctx)
+	if err != nil {
+		t.Fatalf("ListModels on cold worker: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("cold spawn produced empty model list")
+	}
+
+	if !w.IsActive() {
+		t.Fatal("ListModels did not leave pi alive")
+	}
+}


### PR DESCRIPTION
  Adds model listing and switching. Same `Worker.ListModels` / `SetModel`
  plumbing drives both GUI clients (structured socket protocol with
  `list-models` / `set-model` / `models` event) and chat backends
  (`!models` / `!model <provider>/<id>` on matrix / signal / nostr /
  socket).

  Pi has no active-model marker in `get_available_models`, so it's merged
  with `get_state`. Pi is cold-spawned on first call so GUIs populate
  dropdowns before any chat traffic, and every successful switch
  broadcasts the full list to all connected clients so multi-client
  dropdowns reconcile without polling.

  ## Tests

  Pi RPC round-trip via fake-pi stub, socket handler dispatch, worker
  cold-spawn, app-level command parsing, and multi-client reconciliation.
  All green under `-race -count=3`.

  ## Notes

  - Additive protocol — no version bump, no new deps.
  - Out of scope: pi-internal model switches (tool-driven). Would need a
    pi-side push to reconcile GUIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `!models` command to list configured models with active model highlighted
  * Added `!model <provider>/<id>` command to switch between available models
  * Model changes broadcast to all connected clients
  * Updated help text with new model commands

* **Tests**
  * Added comprehensive tests for model listing and switching across multiple clients

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pinpox/opencrow/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->