### PR TITLE
Migrate coding-agent dependency from pi to omp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ A saner alternative to [OpenClaw](https://github.com/openclaw/openclaw).
 </p>
 
 OpenCrow is a messaging bot that bridges chat messages to
-[pi](https://github.com/badlogic/pi-mono), a coding agent with built-in tools,
-session persistence, auto-compaction, and multi-provider LLM support. Instead of
-reimplementing all of that in Go, OpenCrow spawns pi as a long-lived subprocess
-via its RPC protocol and acts as a thin bridge. The bot operates with a single
-active conversation at a time; session data persists across restarts.
+[omp](https://github.com/can1357/oh-my-pi) (Oh My Pi), a coding agent with
+built-in tools, session persistence, auto-compaction, and multi-provider LLM
+support. Instead of reimplementing all of that in Go, OpenCrow spawns omp as a
+long-lived subprocess via its RPC protocol and acts as a thin bridge. The bot
+operates with a single active conversation at a time; session data persists
+across restarts.
 
 OpenCrow supports multiple messaging backends:
 - **Matrix** — E2EE chat rooms via mautrix
@@ -23,12 +24,12 @@ graph LR
     Heartbeat -->|timer| Inbox
     Reminders[(reminders)] -->|due| Inbox
     Trigger["trigger.pipe"] -->|external| Inbox
-    Inbox -->|dequeue| Worker -->|RPC| Pi["pi process"]
+    Inbox -->|dequeue| Worker -->|RPC| Pi["omp process"]
     Pi -->|response| Worker -->|reply| Transport
 ```
 
 The Go bot receives messages from the configured backend, forwards them to the
-pi process, collects the response, and sends it back.
+omp process, collects the response, and sends it back.
 
 > [!WARNING]
 > There is no whitelisting, permission system, or tool filtering. Trying to bolt

--- a/config.go
+++ b/config.go
@@ -82,10 +82,13 @@ type PiConfig struct {
 	Model      string
 	// WorkingDir is the agent's cwd — where it reads/writes user-facing files
 	// like HEARTBEAT.md. In system prompts, refer to this as "working directory".
-	WorkingDir    string
-	IdleTimeout   time.Duration
-	SystemPrompt  string
-	Skills        []string
+	WorkingDir   string
+	IdleTimeout  time.Duration
+	SystemPrompt string
+	Skills       []string
+	// Extensions are omp extension paths (dirs or files) loaded via
+	// --extension — OPENCROW_PI_EXTENSIONS, comma-separated.
+	Extensions    []string
 	ShowToolCalls bool // OPENCROW_SHOW_TOOL_CALLS — relay tool_execution_start events to chat
 	DebugTiming   bool // OPENCROW_DEBUG_TIMING — append timing info to each reply
 }
@@ -139,7 +142,7 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 			Name:       env.or("OPENCROW_SOCKET_NAME", "OpenCrow"),
 		},
 		Pi: PiConfig{
-			BinaryPath:    env.or("OPENCROW_PI_BINARY", "pi"),
+			BinaryPath:    env.or("OPENCROW_PI_BINARY", "omp"),
 			SessionDir:    env.or("OPENCROW_PI_SESSION_DIR", "/var/lib/opencrow/sessions"),
 			Provider:      env.or("OPENCROW_PI_PROVIDER", "anthropic"),
 			Model:         env.or("OPENCROW_PI_MODEL", "claude-opus-4-6"),
@@ -147,6 +150,7 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 			IdleTimeout:   idleTimeout,
 			SystemPrompt:  loadSoul(env),
 			Skills:        skills,
+			Extensions:    env.list("OPENCROW_PI_EXTENSIONS"),
 			ShowToolCalls: env.bool("OPENCROW_SHOW_TOOL_CALLS"),
 			DebugTiming:   env.bool("OPENCROW_DEBUG_TIMING"),
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -268,3 +268,19 @@ func TestDiscoverSkills_Symlinks(t *testing.T) {
 		t.Errorf("skill path = %q, want %q", skills[0], want)
 	}
 }
+
+func TestPiConfig_Extensions(t *testing.T) {
+	t.Parallel()
+
+	env := baseMatrixEnv()
+	env["OPENCROW_PI_EXTENSIONS"] = "/ext/a, /ext/b"
+
+	cfg, err := loadConfig(testEnv(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"/ext/a", "/ext/b"}; !slices.Equal(cfg.Pi.Extensions, want) {
+		t.Errorf("extensions = %v, want %v", cfg.Pi.Extensions, want)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,16 +28,17 @@ Send these as plain text messages in any conversation with the bot:
 | Variable | Default | Description |
 |---|---|---|
 | `OPENCROW_BACKEND` | `matrix` | Messaging backend (`matrix`, `nostr`, or `signal`) |
-| `OPENCROW_PI_BINARY` | `pi` | Path to the pi binary |
+| `OPENCROW_PI_BINARY` | `omp` | Path to the omp binary |
 | `OPENCROW_PI_SESSION_DIR` | `/var/lib/opencrow/sessions` | Session data directory |
 | `OPENCROW_PI_PROVIDER` | `anthropic` | LLM provider |
 | `OPENCROW_PI_MODEL` | `claude-opus-4-6` | Model name |
-| `OPENCROW_PI_WORKING_DIR` | `/var/lib/opencrow` | Working directory for pi |
-| `OPENCROW_PI_IDLE_TIMEOUT` | `30m` | Kill pi after this duration of inactivity |
+| `OPENCROW_PI_WORKING_DIR` | `/var/lib/opencrow` | Working directory for omp |
+| `OPENCROW_PI_IDLE_TIMEOUT` | `30m` | Kill omp after this duration of inactivity |
 | `OPENCROW_PI_SYSTEM_PROMPT` | built-in | Custom system prompt |
 | `OPENCROW_SOUL_FILE` | _(empty)_ | Path to a file containing the system prompt (overrides `OPENCROW_PI_SYSTEM_PROMPT`) |
 | `OPENCROW_PI_SKILLS` | _(empty)_ | Comma-separated skill directory paths |
 | `OPENCROW_PI_SKILLS_DIR` | _(empty)_ | Directory containing skill subdirectories |
+| `OPENCROW_PI_EXTENSIONS` | _(empty)_ | Comma-separated omp extension paths (dirs or files), passed via `--extension` |
 | `OPENCROW_SHOW_TOOL_CALLS` | `false` | Show tool invocations (bash, read, edit, …) as messages in the chat |
 | `OPENCROW_DEBUG_TIMING` | `false` | Append task duration to each reply (useful for profiling local models) |
 
@@ -45,10 +46,10 @@ Send these as plain text messages in any conversation with the bot:
 
 **Receiving files** — Users can send images, audio, video, and documents to the
 bot. Attachments are downloaded to the session directory under `attachments/`
-and the file path is passed to pi so it can read or process the file with its
+and the file path is passed to omp so it can read or process the file with its
 tools. On Nostr, media URLs in DMs are automatically detected and downloaded.
 
-**Sending files back** — Pi can send files to the user by including
+**Sending files back** — omp can send files to the user by including
 `<sendfile>/absolute/path</sendfile>` tags in its response. The bot strips the
 tags, uploads/sends each referenced file (to Matrix via MXC, to a Blossom
 server for Nostr, or directly via signal-cli for Signal), and delivers them as
@@ -139,25 +140,28 @@ services.opencrow = {
 
 ### LLM provider credentials
 
-Pi needs credentials for your LLM provider. There are two ways to set this up:
+omp needs credentials for your LLM provider. There are two ways to set this up:
 
 **Option A: API key** — set `ANTHROPIC_API_KEY` (or the equivalent for your
 provider) in an environment file and pass it via the `environmentFiles` option.
 API keys don't expire and are the simplest approach.
 
-**Option B: OAuth (Claude Pro/Max)** — pi supports OAuth against your Anthropic
+**Option B: OAuth (Claude Pro/Max)** — omp supports OAuth against your Anthropic
 account, so you can use your subscription instead of API credits. The NixOS
-module installs an `opencrow-pi` wrapper on the host that runs pi inside the
-container with the correct environment. To authenticate:
+module installs an `opencrow-pi` wrapper on the host that runs omp inside the
+container with the correct environment. To authenticate, launch an interactive
+session and run the `/login` slash command:
 
 ```bash
-sudo opencrow-pi auth login
+sudo opencrow-pi
+# then, inside the omp session:
+/login anthropic
 ```
 
-Pi will print a URL — open it in any browser, complete the Anthropic login, and
-paste the redirect URL back into the terminal. No local browser is required on
-the server itself. The refresh token persists across restarts — you only need to
-do this once (unless the token gets revoked).
+omp prints a URL — open it in any browser, complete the Anthropic login, and
+paste the redirect URL back with `/login <redirect-url>`. No local browser is
+required on the server itself. Credentials persist in `agent.db` across restarts
+— you only need to do this once (unless they get revoked).
 
 ### Environment files
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,9 +1,9 @@
 # Extensions
 
-Pi supports [extensions](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)
+omp supports [extensions](https://github.com/can1357/oh-my-pi)
 — TypeScript modules that hook into the agent lifecycle, register custom tools,
-and modify behavior. OpenCrow passes extension paths to pi via a generated
-`settings.json` in `PI_CODING_AGENT_DIR`.
+and modify behavior. OpenCrow passes extension paths to omp via its
+`--extension` flag (wired through the `OPENCROW_PI_EXTENSIONS` env var).
 
 ## NixOS module
 
@@ -22,7 +22,7 @@ Setting a value to `false` explicitly disables an extension (useful for
 overriding defaults from other modules). The attrset is mergeable across NixOS
 module files.
 
-Extra keys for pi's `settings.json` (e.g. `packages`, `compaction`) can be
+Extra keys for omp's `config.yml` (e.g. `compaction`) can be
 added via `piSettings`:
 
 ```nix
@@ -53,12 +53,12 @@ See [`extensions/memory/`](../extensions/memory/) for the source.
 
 ## Writing an extension
 
-See the [pi extensions documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md)
+See the [omp extensions documentation](https://github.com/can1357/oh-my-pi)
 for the full API. In short, create a TypeScript file that exports a default
 function receiving the `ExtensionAPI`:
 
 ```typescript
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
   pi.on("agent_end", async (event) => {

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -26,7 +26,7 @@ agent replies `HEARTBEAT_OK` the response is suppressed; anything else is
 delivered to the conversation.
 
 Heartbeat prompts do not reset the idle timer — if no real user messages
-arrive, the pi process is still reaped after the idle timeout.
+arrive, the omp process is still reaped after the idle timeout.
 
 ### Enabling on NixOS
 
@@ -40,7 +40,7 @@ HEARTBEAT.md checklist loop.
 ## Reminders
 
 One-shot reminders live in the `reminders` table in the session's
-`opencrow.db`. Enable the bundled `reminders` pi extension to give the
+`opencrow.db`. Enable the bundled `reminders` omp extension to give the
 agent structured tools:
 
 - `remind_at(when, prompt)` — schedule a reminder (ISO 8601, normalized to UTC)
@@ -51,7 +51,7 @@ Every minute the scheduler runs `DELETE … WHERE fire_at <= now() RETURNING …
 and enqueues each due reminder as a trigger item. Cleanup is atomic — the
 agent never manages lifecycle.
 
-`OPENCROW_SESSION_DIR` is exported into pi's environment automatically.
+`OPENCROW_SESSION_DIR` is exported into omp's environment automatically.
 
 ### Enabling on NixOS
 
@@ -78,7 +78,7 @@ immediately without waiting for a tick.
 
 > [!CAUTION]
 > The trigger pipe is an **unauthenticated** input channel. Any process
-> that can write to the FIFO can inject arbitrary prompts into `pi`, which
+> that can write to the FIFO can inject arbitrary prompts into `omp`, which
 > has full tool access. The FIFO is created with mode `0664`, so any
 > process in the `opencrow` group can write to it. Make sure only trusted
 > services are members of that group.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,12 +1,12 @@
 # Skills
 
-Pi supports skills — markdown files that extend the agent's capabilities by
+omp supports skills — markdown files that extend the agent's capabilities by
 providing instructions and examples for specific tasks. Each skill is a directory
 containing a `SKILL.md` file with a YAML frontmatter (`name`, `description`) and
 the skill's instructions.
 
 OpenCrow ships with a `web` skill (for browsing with curl/lynx) and passes it to
-pi by default.
+omp by default.
 
 ## NixOS module
 
@@ -22,7 +22,7 @@ services.opencrow.skills = {
 ```
 
 All entries are assembled into a single directory via `linkFarm` and passed to
-pi through `OPENCROW_PI_SKILLS_DIR`. The attrset is mergeable, so skills can be
+omp through `OPENCROW_PI_SKILLS_DIR`. The attrset is mergeable, so skills can be
 added from multiple NixOS module files.
 
 ## Environment variables

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -14,7 +14,7 @@ isolation.
     opencrow.url = "github:pinpox/opencrow";
     opencrow.inputs.nixpkgs.follows = "nixpkgs";
 
-    # pi coding agent
+    # omp (Oh My Pi) coding agent
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -50,7 +50,7 @@ Or extract it from an existing Matrix client's session.
 
   services.opencrow = {
     enable = true;
-    piPackage = self.inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.pi;
+    piPackage = self.inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.omp;
 
     environment = {
       OPENCROW_MATRIX_HOMESERVER = "https://matrix.org";
@@ -96,11 +96,13 @@ subscription, skip `ANTHROPIC_API_KEY` and authenticate interactively after
 deployment:
 
 ```bash
-sudo opencrow-pi auth login
+sudo opencrow-pi
+# then, inside the omp session:
+/login anthropic
 ```
 
-Pi prints a URL — open it in any browser, log in, and paste the redirect URL
-back into the terminal.
+omp prints a URL — open it in any browser, log in, and paste the redirect URL
+back with `/login <redirect-url>`.
 
 ## 5. Deploy and verify
 
@@ -113,7 +115,7 @@ machinectl list
 # Follow the bot logs
 journalctl -M opencrow -u opencrow -f
 
-# Interactive pi shell inside the container (requires root)
+# Interactive omp shell inside the container (requires root)
 sudo opencrow-pi
 ```
 

--- a/extensions/memory/index.ts
+++ b/extensions/memory/index.ts
@@ -21,13 +21,12 @@
 import {
   convertToLlm,
   serializeConversation,
-} from "@mariozechner/pi-coding-agent";
+} from "@oh-my-pi/pi-coding-agent";
 import type {
   ExtensionAPI,
   ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
-import { complete } from "@mariozechner/pi-ai";
-import { Type } from "@sinclair/typebox";
+} from "@oh-my-pi/pi-coding-agent";
+import { complete } from "@oh-my-pi/pi-ai";
 
 const SEDIMENT_BIN = "@@SEDIMENT_BIN@@";
 const SEDIMENT_TIMEOUT = 10_000;
@@ -391,6 +390,8 @@ async function extractFacts(
 // ── extension ────────────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+  const { Type } = pi.typebox;
+
   // Compaction summaries are the narrative layer — store whole.
   pi.on("session_compact", async (event) => {
     const summary = event.compactionEntry.summary?.trim();

--- a/extensions/reminders/index.ts
+++ b/extensions/reminders/index.ts
@@ -14,8 +14,7 @@
  * cleanup is owned by the opencrow process.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 // Nix build substitutes the store path here. If the placeholder survives
 // (non-Nix install), fall back to PATH lookup.
@@ -87,6 +86,8 @@ export default function remindersExtension(pi: ExtensionAPI) {
     // missing we are running outside opencrow — silently skip.
     return;
   }
+
+  const { Type } = pi.typebox;
 
   async function sqlite(sql: string, signal?: AbortSignal): Promise<string> {
     const result = await pi.exec(

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -9,6 +9,7 @@ let
   cfg = config.services.opencrow;
 
   jsonFormat = pkgs.formats.json { };
+  yamlFormat = pkgs.formats.yaml { };
 
   # Derive container name and state directory from instance name.
   # The "default" instance (top-level enable) keeps the original
@@ -41,8 +42,8 @@ let
 
       piPackage = lib.mkOption {
         type = lib.types.package;
-        description = "The pi coding agent package. Required — typically from llm-agents.nix or similar.";
-        example = lib.literalExpression "llm-agents.packages.\${system}.pi";
+        description = "The omp (Oh My Pi) coding agent package. Required — typically from llm-agents.nix or similar.";
+        example = lib.literalExpression "llm-agents.packages.\${system}.omp";
       };
 
       signalCliPackage = lib.mkOption {
@@ -84,8 +85,8 @@ let
           - `false` to explicitly disable an extension
           - A path to a .ts file or directory containing an index.ts
 
-          All enabled extensions are written into a generated settings.json
-          that pi reads from PI_CODING_AGENT_DIR.
+          All enabled extensions are passed to omp via --extension
+          (opencrow exports OPENCROW_PI_EXTENSIONS for the bot to forward).
 
           Bundled extensions: `memory` (cross-session recall via sediment),
           `reminders` (remind_at/list/cancel tools backed by opencrow.db).
@@ -104,9 +105,9 @@ let
         type = jsonFormat.type;
         default = { };
         description = ''
-          Extra keys to include in the generated pi settings.json.
-          The `extensions` key is automatically populated from the
-          `extensions` option and should not be set here.
+          Extra keys to include in the generated omp config.yml (settings).
+          Extensions are NOT configured here — use the `extensions` option,
+          which opencrow loads via omp's --extension flag.
         '';
         example = lib.literalExpression ''
           {
@@ -120,12 +121,12 @@ let
         type = jsonFormat.type;
         default = { };
         description = ''
-          Contents of pi's models.json. Use this to add custom
+          Contents of omp's models.yml. Use this to add custom
           providers or override properties of built-in models via
           `modelOverrides` — most commonly `contextWindow` when the
-          configured API tier is narrower than pi's published value
+          configured API tier is narrower than omp's published value
           (e.g. Anthropic's long-context requires separate usage
-          credits). Without the override pi's auto-compaction never
+          credits). Without the override omp's auto-compaction never
           triggers and every turn bounces off a 429.
         '';
         example = lib.literalExpression ''
@@ -341,7 +342,7 @@ let
             OPENCROW_PI_SKILLS = lib.mkOption {
               type = lib.types.str;
               default = "";
-              description = "Comma-separated list of additional skill paths to pass to pi via --skill. Prefer using the top-level `skills` option instead.";
+              description = "Comma-separated list of additional skill paths. opencrow registers them with omp via a generated skills.customDirectories config overlay. Prefer using the top-level `skills` option instead.";
             };
 
             OPENCROW_PI_SKILLS_DIR = lib.mkOption {
@@ -426,14 +427,12 @@ let
         if value == true then self.packages.${pkgs.hostPlatform.system}."extension-${ename}" else value
       ) (lib.filterAttrs (_: v: v != false) icfg.extensions);
 
-      # Generate a settings.json for pi that lists declared extensions.
-      # Installed into PI_CODING_AGENT_DIR at service startup so pi
-      # auto-discovers them.
-      piSettingsJson = jsonFormat.generate "pi-settings-${name}.json" (
-        icfg.piSettings // { extensions = lib.attrValues resolvedExtensions; }
-      );
+      # omp loads extensions explicitly via --extension (opencrow passes
+      # them from OPENCROW_PI_EXTENSIONS); they are not auto-discovered from
+      # the agent dir. Settings/models are installed into PI_CODING_AGENT_DIR.
+      piConfigYml = yamlFormat.generate "omp-config-${name}.yml" icfg.piSettings;
 
-      piModelsJson = jsonFormat.generate "pi-models-${name}.json" icfg.piModels;
+      piModelsYml = yamlFormat.generate "omp-models-${name}.yml" icfg.piModels;
 
       # Host-side wrapper to interact with pi inside the container as the opencrow user.
       opencrowPi = pkgs.writeShellScriptBin "${containerName}-pi" ''
@@ -542,19 +541,21 @@ let
             };
             users.groups.opencrow = { };
 
-            # Place the generated settings.json into PI_CODING_AGENT_DIR
-            # so pi discovers declared extensions and packages.
+            # Install omp's config.yml (settings) and models.yml into
+            # PI_CODING_AGENT_DIR. Extensions are passed on the command line.
             systemd.tmpfiles.rules = [
               # Fix up ownership of the bind-mounted state dir. The host side
               # created it as root because the opencrow user does not exist
               # there; inside the container we know the UID and can chown it.
               "d ${stateDir} 0750 opencrow opencrow -"
               "d ${icfg.environment.PI_CODING_AGENT_DIR} 0750 opencrow opencrow -"
-              "L+ ${icfg.environment.PI_CODING_AGENT_DIR}/settings.json - - - - ${piSettingsJson}"
             ]
             ++ lib.optional (
+              icfg.piSettings != { }
+            ) "L+ ${icfg.environment.PI_CODING_AGENT_DIR}/config.yml - - - - ${piConfigYml}"
+            ++ lib.optional (
               icfg.piModels != { }
-            ) "L+ ${icfg.environment.PI_CODING_AGENT_DIR}/models.json - - - - ${piModelsJson}";
+            ) "L+ ${icfg.environment.PI_CODING_AGENT_DIR}/models.yml - - - - ${piModelsYml}";
 
             systemd.services.opencrow = {
               description = "OpenCrow Messaging Bot (${name})";
@@ -577,6 +578,11 @@ let
               // lib.filterAttrs (_: v: v != "") icfg.environment
               // lib.optionalAttrs (icfg.extensions.memory or false == true) {
                 SEDIMENT_DB = "${stateDir}/sediment";
+              }
+              // lib.optionalAttrs (resolvedExtensions != { }) {
+                OPENCROW_PI_EXTENSIONS = lib.concatStringsSep "," (
+                  map toString (lib.attrValues resolvedExtensions)
+                );
               };
 
               serviceConfig = {
@@ -624,7 +630,7 @@ in
               {
                 mybot = {
                   enable = true;
-                  piPackage = llm-agents.packages.''${system}.pi;
+                  piPackage = llm-agents.packages.''${system}.omp;
                   environment = {
                     OPENCROW_BACKEND = "nostr";
                     OPENCROW_NOSTR_RELAYS = "wss://relay.damus.io";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
   '';
 
   meta = {
-    description = "Messaging bot (Matrix/Nostr/Signal) bridging messages to an AI coding agent via pi RPC";
+    description = "Messaging bot (Matrix/Nostr/Signal) bridging messages to the omp (Oh My Pi) coding agent via RPC";
     homepage = "https://github.com/pinpox/opencrow";
     mainProgram = "opencrow";
   };

--- a/pi.go
+++ b/pi.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -66,7 +67,12 @@ func StartPi(cfg PiConfig, roomID string, fresh bool) (*PiProcess, error) {
 		return nil, fmt.Errorf("creating trigger FIFO: %w", err)
 	}
 
-	args := buildPiArgs(cfg, fresh)
+	skillsConfigPath, err := writeSkillsConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	args := buildPiArgs(cfg, fresh, skillsConfigPath)
 
 	// context.Background: see the doc comment on StartPi.
 	cmd := exec.CommandContext(context.Background(), cfg.BinaryPath, args...) //nolint:gosec // binary path is from trusted config
@@ -187,7 +193,7 @@ func startPiProcess(cmd *exec.Cmd, sessionDir string) (*PiProcess, error) {
 	}, nil
 }
 
-func buildPiArgs(cfg PiConfig, fresh bool) []string {
+func buildPiArgs(cfg PiConfig, fresh bool, skillsConfigPath string) []string {
 	args := append([]string(nil), cfg.BinaryArgs...)
 
 	args = append(args, "--mode", "rpc", "--session-dir", cfg.SessionDir)
@@ -207,9 +213,56 @@ func buildPiArgs(cfg PiConfig, fresh bool) []string {
 		args = append(args, "--append-system-prompt", cfg.SystemPrompt)
 	}
 
-	for _, skill := range cfg.Skills {
-		args = append(args, "--skill", skill)
+	// omp has no per-skill flag (pi's --skill); skills are registered via
+	// a generated config overlay (skills.customDirectories). See writeSkillsConfig.
+	if skillsConfigPath != "" {
+		args = append(args, "--config", skillsConfigPath)
+	}
+
+	for _, ext := range cfg.Extensions {
+		args = append(args, "--extension", ext)
 	}
 
 	return args
+}
+
+// writeSkillsConfig writes an omp --config overlay that registers the
+// configured skills. omp dropped pi's per-skill --skill flag in favour of
+// scanning skills.customDirectories for */SKILL.md, so each skill directory
+// is mapped to its parent directory. The overlay is written as JSON, which
+// omp parses as a config.yml-style YAML mapping. Returns "" when no skills
+// are configured.
+func writeSkillsConfig(cfg PiConfig) (string, error) {
+	if len(cfg.Skills) == 0 {
+		return "", nil
+	}
+
+	seen := make(map[string]struct{}, len(cfg.Skills))
+	dirs := make([]string, 0, len(cfg.Skills))
+
+	for _, skill := range cfg.Skills {
+		parent := filepath.Dir(skill)
+		if _, ok := seen[parent]; ok {
+			continue
+		}
+
+		seen[parent] = struct{}{}
+		dirs = append(dirs, parent)
+	}
+
+	overlay := map[string]any{
+		"skills": map[string]any{"customDirectories": dirs},
+	}
+
+	data, err := json.Marshal(overlay)
+	if err != nil {
+		return "", fmt.Errorf("marshaling skills config: %w", err)
+	}
+
+	path := filepath.Join(cfg.SessionDir, "omp-skills.yaml")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("writing skills config: %w", err)
+	}
+
+	return path, nil
 }

--- a/pi_format.go
+++ b/pi_format.go
@@ -34,9 +34,9 @@ func logSimpleRPCEvent(evt rpcEvent) {
 		slog.Info("pi: agent started")
 	case rpcTypeAgentEnd:
 		slog.Info("pi: agent finished")
-	case "compaction_start":
+	case rpcTypeAutoCompactionStart:
 		slog.Info("pi: compaction started", "reason", evt.Reason)
-	case "compaction_end":
+	case "auto_compaction_end":
 		slog.Info("pi: compaction finished")
 	case "turn_start", "turn_end", "message_start", "message_end", rpcTypeExtensionUIRequest:
 		slog.Debug("pi: " + evt.Type)
@@ -46,7 +46,8 @@ func logSimpleRPCEvent(evt rpcEvent) {
 }
 
 func logAutoRetryStart(evt rpcEvent) {
-	slog.Warn("pi: auto-retry",
+	slog.Warn(
+		"pi: auto-retry",
 		"attempt", evt.Attempt,
 		"max", evt.MaxAttempts,
 		"delay_ms", evt.DelayMs,
@@ -63,7 +64,8 @@ func logAutoRetryEnd(evt rpcEvent) {
 }
 
 func logExtensionError(evt rpcEvent) {
-	slog.Error("pi: extension error",
+	slog.Error(
+		"pi: extension error",
 		"extension", evt.ExtensionPath,
 		"event", evt.Event,
 		"error", evt.Error,

--- a/pi_rpc.go
+++ b/pi_rpc.go
@@ -50,7 +50,7 @@ type rpcEvent struct {
 	// auto_retry_end fields — camelCase is dictated by the pi protocol.
 	FinalError string `json:"finalError,omitempty"` //nolint:tagliatelle // pi protocol uses camelCase
 
-	// compaction_start fields
+	// auto_compaction_start fields
 	Reason string `json:"reason,omitempty"`
 
 	// extension_error fields
@@ -102,6 +102,7 @@ const (
 	rpcTypeAutoRetryEnd        = "auto_retry_end"
 	rpcTypeExtensionError      = "extension_error"
 	rpcTypeExtensionUIRequest  = "extension_ui_request"
+	rpcTypeAutoCompactionStart = "auto_compaction_start"
 )
 
 // Compact sends a compact command to reduce context token usage.
@@ -293,7 +294,7 @@ func (p *PiProcess) handleSideEffects(evt rpcEvent) error {
 // final — if retry is disabled or the error isn't in pi's retryable
 // set, no auto_retry_* events follow and pi just goes idle with
 // nothing further on the wire. We must therefore commit the error
-// immediately on agent_end and let auto_retry_start/compaction_start
+// immediately on agent_end and let auto_retry_start/auto_compaction_start
 // rescind it if they arrive next.
 type resultWaiter struct {
 	reply    string
@@ -306,7 +307,7 @@ type resultWaiter struct {
 // overflow-triggered auto-compaction. Both are followed by a fresh
 // agent_start/end cycle, so the error that preceded them wasn't final.
 func continuesTurn(t string) bool {
-	return t == rpcTypeAutoRetryStart || t == "compaction_start"
+	return t == rpcTypeAutoRetryStart || t == rpcTypeAutoCompactionStart
 }
 
 func (w *resultWaiter) handle(evt rpcEvent) (bool, error) {
@@ -338,7 +339,7 @@ func (w *resultWaiter) handle(evt rpcEvent) (bool, error) {
 }
 
 // graceDrain peeks at the events channel for up to errGraceWindow,
-// looking for an auto_retry_start or compaction_start that would
+// looking for an auto_retry_start or auto_compaction_start that would
 // rescind a just-committed error. Returns true if one arrived (caller
 // should keep draining), false if the window elapsed or the channel
 // closed. Reads bypass drainEvents so we don't re-run side effects.
@@ -379,7 +380,7 @@ func (w *resultWaiter) handleAgentEnd(evt rpcEvent) {
 		// Commit immediately — if pi deems the error non-retryable
 		// it goes idle with nothing further on the wire, so waiting
 		// for a follow-up would hang. graceDrain gives a subsequent
-		// auto_retry_start or compaction_start a short window
+		// auto_retry_start or auto_compaction_start a short window
 		// to rescind this.
 		w.finalErr = last.errorMessage
 		slog.Warn("agent_end: provider error", "error", last.errorMessage)
@@ -393,7 +394,7 @@ func (w *resultWaiter) handleAgentEnd(evt rpcEvent) {
 }
 
 // errGraceWindow is how long we wait after an error agent_end for a
-// rescinding auto_retry_start or compaction_start before treating
+// rescinding auto_retry_start or auto_compaction_start before treating
 // the error as final. Pi emits the follow-up within milliseconds
 // (same event-queue tick), so 200ms is generous without adding
 // perceptible latency to the rare "pi gave up and went idle" path.

--- a/pi_test.go
+++ b/pi_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -135,3 +139,104 @@ func agentEnd(stop, errMsg, text string) rpcEvent {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func TestBuildPiArgs_SkillsAndExtensions(t *testing.T) {
+	t.Parallel()
+
+	cfg := PiConfig{
+		SessionDir:   "/sess",
+		Provider:     "anthropic",
+		Model:        "claude-opus-4-6",
+		SystemPrompt: "be nice",
+		Extensions:   []string{"/ext/memory", "/ext/reminders"},
+	}
+
+	args := buildPiArgs(cfg, false, "/sess/omp-skills.yaml")
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"--mode rpc",
+		"--session-dir /sess",
+		"--continue",
+		"--provider anthropic",
+		"--model claude-opus-4-6",
+		"--append-system-prompt be nice",
+		"--config /sess/omp-skills.yaml",
+		"--extension /ext/memory",
+		"--extension /ext/reminders",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, args)
+		}
+	}
+
+	// omp has no --skill flag; emitting it makes omp refuse to start.
+	if slices.Contains(args, "--skill") {
+		t.Errorf("buildPiArgs must never emit --skill: %v", args)
+	}
+}
+
+func TestBuildPiArgs_FreshAndNoSkills(t *testing.T) {
+	t.Parallel()
+
+	args := buildPiArgs(PiConfig{SessionDir: "/sess"}, true, "")
+
+	if slices.Contains(args, "--continue") {
+		t.Errorf("fresh=true must omit --continue: %v", args)
+	}
+
+	if slices.Contains(args, "--config") {
+		t.Errorf("empty skills config path must omit --config: %v", args)
+	}
+}
+
+func TestWriteSkillsConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// No skills -> no overlay file, empty path.
+	path, err := writeSkillsConfig(PiConfig{SessionDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if path != "" {
+		t.Errorf("no skills should yield empty path, got %q", path)
+	}
+
+	// Skill directories map to their parent dirs (omp scans */SKILL.md);
+	// a shared parent is deduped, first-seen order preserved.
+	cfg := PiConfig{
+		SessionDir: dir,
+		Skills:     []string{"/a/web", "/a/git", "/b/pdf"},
+	}
+
+	path, err = writeSkillsConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := filepath.Join(dir, "omp-skills.yaml"); path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// JSON is a subset of YAML, so this is what omp parses as the overlay.
+	var got struct {
+		Skills struct {
+			CustomDirectories []string `json:"customDirectories"` //nolint:tagliatelle // omp config uses camelCase
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("overlay not valid JSON/YAML: %v\n%s", err, data)
+	}
+
+	if want := []string{"/a", "/b"}; !slices.Equal(got.Skills.CustomDirectories, want) {
+		t.Errorf("customDirectories = %v, want %v", got.Skills.CustomDirectories, want)
+	}
+}


### PR DESCRIPTION
Swap the bridged coding agent from pi (badlogic/pi-mono) to omp (Oh My Pi). Keeps all OPENCROW_PI_* env vars, PiConfig/PiProcess names, and the opencrow-pi wrapper for backward compatibility.

- buildPiArgs: drop pi's --skill flag (omp rejects it); register skills via a generated --config overlay (skills.customDirectories), and load extensions via omp's --extension flag (new OPENCROW_PI_EXTENSIONS env).
- Default OPENCROW_PI_BINARY is now omp.
- Reconcile the auto-compaction event name (compaction_start -> auto_compaction_start) in the retry-rescind logic and event logging.
- Extensions: import scope @mariozechner/* -> @oh-my-pi/*, schemas via the pi.typebox shim (omp no longer bundles @sinclair/typebox).
- NixOS module: piPackage -> omp; write config.yml + models.yml instead of settings.json/models.json; pass extensions through OPENCROW_PI_EXTENSIONS.
- Docs: dependency, extension/skill mechanisms, and OAuth login (/login).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched the bridged coding agent configuration and defaults from **pi** to **omp**.
  * Added support for loading multiple extension paths from an environment variable and passing them into the agent.
  * Improved skills handling by generating a reusable configuration overlay for agent sessions.

* **Bug Fixes**
  * Updated event handling for automatic compaction and retry flows to keep session logging and recovery behavior consistent.

* **Documentation**
  * Updated setup guides, configuration docs, and tutorials to match the new **omp**-based workflow and file-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->