### PR TITLE
feat(matrix): support password login via OPENCROW_MATRIX_PASSWORD[_FILE]

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ type MatrixConfig struct {
 	Homeserver   string
 	UserID       string
 	AccessToken  string
+	Password     string
 	DeviceID     string
 	AllowedUsers map[string]struct{}
 	PickleKey    string
@@ -125,12 +126,18 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 		return nil, err
 	}
 
+	matrixPassword, err := loadMatrixPassword(env)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		BackendType: backendType,
 		Matrix: MatrixConfig{
 			Homeserver:   env.str("OPENCROW_MATRIX_HOMESERVER"),
 			UserID:       env.str("OPENCROW_MATRIX_USER_ID"),
 			AccessToken:  env.str("OPENCROW_MATRIX_ACCESS_TOKEN"),
+			Password:     matrixPassword,
 			DeviceID:     env.str("OPENCROW_MATRIX_DEVICE_ID"),
 			AllowedUsers: allowedUsers,
 			PickleKey:    env.or("OPENCROW_MATRIX_PICKLE_KEY", "opencrow-default-pickle-key"),
@@ -167,6 +174,17 @@ func loadConfig(getenv func(string) string) (*Config, error) {
 	return cfg, nil
 }
 
+func loadMatrixPassword(env envReader) (string, error) {
+	if path := env.str("OPENCROW_MATRIX_PASSWORD_FILE"); path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading OPENCROW_MATRIX_PASSWORD_FILE: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	return env.str("OPENCROW_MATRIX_PASSWORD"), nil
+}
+
 func (cfg *Config) validateBackend(env envReader) error {
 	switch cfg.BackendType {
 	case backendMatrix:
@@ -188,11 +206,14 @@ func (cfg *Config) validateBackend(env envReader) error {
 }
 
 func (m MatrixConfig) validate() error {
-	return errors.Join(
+	err := errors.Join(
 		requireField(m.Homeserver, "OPENCROW_MATRIX_HOMESERVER"),
 		requireField(m.UserID, "OPENCROW_MATRIX_USER_ID"),
-		requireField(m.AccessToken, "OPENCROW_MATRIX_ACCESS_TOKEN"),
 	)
+	if m.AccessToken == "" && m.Password == "" {
+		err = errors.Join(err, errors.New("OPENCROW_MATRIX_ACCESS_TOKEN or OPENCROW_MATRIX_PASSWORD is required"))
+	}
+	return err
 }
 
 func loadSignalConfig(env envReader, workingDir string, allowedUsers map[string]struct{}) SignalConfig {

--- a/config_test.go
+++ b/config_test.go
@@ -28,6 +28,28 @@ func TestMatrixConfig_ValidateReportsAllMissing(t *testing.T) {
 	}
 }
 
+func TestMatrixConfig_PasswordSatisfiesTokenRequirement(t *testing.T) {
+	t.Parallel()
+
+	// Password instead of an access token is valid.
+	if err := (MatrixConfig{
+		Homeserver: "https://matrix.example.com",
+		UserID:     "@bot:example.com",
+		Password:   "hunter2",
+	}).validate(); err != nil {
+		t.Errorf("password-only config should validate, got: %v", err)
+	}
+
+	// Access token alone remains valid (backwards compatible).
+	if err := (MatrixConfig{
+		Homeserver:  "https://matrix.example.com",
+		UserID:      "@bot:example.com",
+		AccessToken: "syt_test_token",
+	}).validate(); err != nil {
+		t.Errorf("token-only config should validate, got: %v", err)
+	}
+}
+
 // testEnv returns a getenv function backed by a map.
 func testEnv(m map[string]string) func(string) string {
 	return func(key string) string {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,11 +61,15 @@ attachments. Multiple `<sendfile>` tags can appear in a single response.
 |---|---|---|
 | `OPENCROW_MATRIX_HOMESERVER` | Yes | Matrix homeserver URL |
 | `OPENCROW_MATRIX_USER_ID` | Yes | Bot's Matrix user ID |
-| `OPENCROW_MATRIX_ACCESS_TOKEN` | Yes | Access token (via environment file) |
+| `OPENCROW_MATRIX_ACCESS_TOKEN` | Yes* | Access token (via environment file) |
+| `OPENCROW_MATRIX_PASSWORD_FILE` | Yes* | Path to a file with the account password; OpenCrow logs in to obtain a token |
+| `OPENCROW_MATRIX_PASSWORD` | Yes* | Account password (prefer the `_FILE` form) |
 | `OPENCROW_MATRIX_DEVICE_ID` | No | Device ID (auto-resolved if omitted) |
 | `OPENCROW_MATRIX_PICKLE_KEY` | No | Pickle key for crypto DB |
 | `OPENCROW_MATRIX_CRYPTO_DB` | No | Path to crypto SQLite DB |
 | `OPENCROW_ALLOWED_USERS` | No | Comma-separated Matrix user IDs allowed to interact |
+
+*One of `OPENCROW_MATRIX_ACCESS_TOKEN`, `OPENCROW_MATRIX_PASSWORD_FILE`, or `OPENCROW_MATRIX_PASSWORD` is required. With a password, OpenCrow logs in on first start and persists the resulting token + device to `matrix-session.json` (next to the crypto DB), reusing it across restarts.
 
 ## Nostr configuration
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -38,6 +38,10 @@ curl -s -X POST https://matrix.org/_matrix/client/v3/login \
 
 Or extract it from an existing Matrix client's session.
 
+Alternatively, skip the manual token entirely: set `OPENCROW_MATRIX_PASSWORD_FILE`
+(or `OPENCROW_MATRIX_PASSWORD`) and OpenCrow logs in on first start, then persists
+and reuses the token across restarts.
+
 ## 3. Import the module and configure the bot
 
 ```nix

--- a/main.go
+++ b/main.go
@@ -270,6 +270,7 @@ func createMatrixBackend(cfg *Config, handler backend.MessageHandler, onRoomClea
 		Homeserver:     cfg.Matrix.Homeserver,
 		UserID:         cfg.Matrix.UserID,
 		AccessToken:    cfg.Matrix.AccessToken,
+		Password:       cfg.Matrix.Password,
 		DeviceID:       cfg.Matrix.DeviceID,
 		AllowedUsers:   cfg.Matrix.AllowedUsers,
 		PickleKey:      cfg.Matrix.PickleKey,

--- a/matrix/backend.go
+++ b/matrix/backend.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -36,6 +37,7 @@ type Config struct {
 	Homeserver     string
 	UserID         string
 	AccessToken    string
+	Password       string
 	DeviceID       string
 	AllowedUsers   map[string]struct{}
 	PickleKey      string
@@ -76,6 +78,15 @@ func New(cfg Config, handler backend.MessageHandler) (*Backend, error) {
 		w.Out = os.Stderr
 	})).With().Timestamp().Logger().Level(zerolog.InfoLevel)
 
+	// Backward compatible: with a token, behave exactly as before. Only when no
+	// token is supplied do we log in with the password to obtain one (persisted
+	// and reused across restarts so the device — and thus E2EE — stays stable).
+	if cfg.AccessToken == "" {
+		if err := ensurePasswordLogin(client, cfg); err != nil {
+			return nil, fmt.Errorf("matrix password login: %w", err)
+		}
+	}
+
 	return &Backend{
 		client:       client,
 		handler:      handler,
@@ -83,6 +94,79 @@ func New(cfg Config, handler backend.MessageHandler) (*Backend, error) {
 		userID:       id.UserID(cfg.UserID),
 		allowedUsers: cfg.AllowedUsers,
 	}, nil
+}
+
+type storedSession struct {
+	AccessToken string `json:"access_token"`
+	DeviceID    string `json:"device_id"`
+}
+
+func sessionPath(cfg Config) string {
+	return filepath.Join(filepath.Dir(cfg.CryptoDBPath), "matrix-session.json")
+}
+
+// ensurePasswordLogin obtains an access token via password login when none was
+// configured, reusing a previously persisted token (and device) when still
+// valid so restarts do not spawn new devices or break E2EE.
+func ensurePasswordLogin(client *mautrix.Client, cfg Config) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := sessionPath(cfg)
+
+	if data, err := os.ReadFile(path); err == nil {
+		var s storedSession
+		if json.Unmarshal(data, &s) == nil && s.AccessToken != "" {
+			client.AccessToken = s.AccessToken
+			if s.DeviceID != "" {
+				client.DeviceID = id.DeviceID(s.DeviceID)
+			}
+			if _, err := client.Whoami(ctx); err == nil {
+				slog.Info("matrix: reusing stored access token", "device_id", client.DeviceID)
+				return nil
+			}
+			slog.Warn("matrix: stored access token invalid, logging in again")
+			client.AccessToken = ""
+		}
+	}
+
+	deviceID := cfg.DeviceID
+	if deviceID == "" {
+		deviceID = "opencrow"
+	}
+
+	resp, err := client.Login(ctx, &mautrix.ReqLogin{
+		Type: mautrix.AuthTypePassword,
+		Identifier: mautrix.UserIdentifier{
+			Type: mautrix.IdentifierTypeUser,
+			User: cfg.UserID,
+		},
+		Password:                 cfg.Password,
+		DeviceID:                 id.DeviceID(deviceID),
+		InitialDeviceDisplayName: "opencrow",
+		StoreCredentials:         true,
+	})
+	if err != nil {
+		return err
+	}
+
+	slog.Info("matrix: logged in with password", "device_id", resp.DeviceID)
+
+	data, err := json.Marshal(storedSession{
+		AccessToken: resp.AccessToken,
+		DeviceID:    string(resp.DeviceID),
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("persisting matrix session: %w", err)
+	}
+
+	return nil
 }
 
 // SetRoomCleanupCallback sets the callback invoked when a room is cleaned up.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -143,7 +143,7 @@ let
           List of environment files containing secrets (on the host).
           Bind-mounted read-only into the container.
           Must define at minimum (across all files):
-          - For Matrix: OPENCROW_MATRIX_ACCESS_TOKEN
+          - For Matrix: OPENCROW_MATRIX_ACCESS_TOKEN, or OPENCROW_MATRIX_PASSWORD_FILE / OPENCROW_MATRIX_PASSWORD
           - For Nostr: OPENCROW_NOSTR_PRIVATE_KEY or OPENCROW_NOSTR_PRIVATE_KEY_FILE
           - ANTHROPIC_API_KEY (or the appropriate key for your provider)
         '';


### PR DESCRIPTION
When no access token is configured, log in with the account password and persist the resulting token + device to matrix-session.json, reusing it across restarts (whoami-checked, stable device id so E2EE stays intact).

Token-based configs are unchanged (backward compatible). Adds docs (configuration.md, tutorial.md, module option) and a validate test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Matrix sign-in can now use a password as an alternative to an access token.
  * When using a password, the app can log in on first start and reuse the generated session on later restarts.

* **Bug Fixes**
  * Improved Matrix setup validation so either an access token or password is accepted.
  * Better handled Matrix session persistence to reduce repeated logins.

* **Documentation**
  * Updated configuration and tutorial docs to cover password-based Matrix authentication and the related secret file option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->